### PR TITLE
docs: Add GitHub Pages branch information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Endpoint
+
+## GitHub Pages
+
+This project uses GitHub Pages for documentation and project information.
+
+**Branch:** `gh-pages`
+
+The GitHub Pages site is served from the `gh-pages` branch. To view the live site, visit the repository's GitHub Pages URL.
+
+### Contributing to Documentation
+
+To update the GitHub Pages content:
+
+1. Switch to the `gh-pages` branch: `git checkout gh-pages`
+2. Make your changes
+3. Commit and push to the `gh-pages` branch


### PR DESCRIPTION
Document that the project uses gh-pages branch for GitHub Pages, and provide instructions for contributing to the documentation.