### PR TITLE
Fix GitHub Pages rendering by adding Jekyll configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,5 @@
+title: Endpoint
+description: A powerful template-based design-time code generator for .NET applications
+remote_theme: pages-themes/minimal@v0.2.0
+plugins:
+  - jekyll-remote-theme

--- a/index.md
+++ b/index.md
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+{% include_relative README.md %}


### PR DESCRIPTION
Add _config.yml with minimal theme and index.md that includes the README content, allowing the GitHub Pages site to properly render the documentation.