### PR TITLE
Validate PlantUML solution architecture files

### DIFF
--- a/src/Endpoint.Cli/Commands/SolutionPlantumlValidate.cs
+++ b/src/Endpoint.Cli/Commands/SolutionPlantumlValidate.cs
@@ -1,38 +1,141 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using CommandLine;
-using MediatR;
-using Microsoft.Extensions.Logging;
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using CommandLine;
+using Endpoint.DotNet.Artifacts.PlantUml.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Endpoint.Cli.Commands;
 
 [Verb("solution-plantuml-validate")]
-public class SolutionPlantumlValidateRequest : IRequest {
-    [Option('n',"name")]
+public class SolutionPlantumlValidateRequest : IRequest
+{
+    [Option('n', "name", Required = false, HelpText = "Optional name for the validation report.")]
     public string Name { get; set; }
 
     [Option('p', "plant-uml-source-path", Required = true, HelpText = "Path to the directory containing PlantUML files.")]
     public string PlantUmlSourcePath { get; set; }
 
-    [Option('d', Required = false)]
-    public string Directory { get; set; } = System.Environment.CurrentDirectory;
+    [Option('d', "directory", Required = false, HelpText = "Directory where the validation report will be saved.")]
+    public string Directory { get; set; } = Environment.CurrentDirectory;
 }
 
 public class SolutionPlantumlValidateRequestHandler : IRequestHandler<SolutionPlantumlValidateRequest>
 {
-    private readonly ILogger<SolutionPlantumlValidateRequestHandler> _logger;
+    private readonly ILogger<SolutionPlantumlValidateRequestHandler> logger;
+    private readonly IPlantUmlValidationService validationService;
 
-    public SolutionPlantumlValidateRequestHandler(ILogger<SolutionPlantumlValidateRequestHandler> logger)
+    public SolutionPlantumlValidateRequestHandler(
+        ILogger<SolutionPlantumlValidateRequestHandler> logger,
+        IPlantUmlValidationService validationService)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.validationService = validationService ?? throw new ArgumentNullException(nameof(validationService));
     }
 
     public async Task Handle(SolutionPlantumlValidateRequest request, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Handled: {0}", nameof(SolutionPlantumlValidateRequestHandler));
+        logger.LogInformation("Validating PlantUML solution architecture files");
+        logger.LogInformation("PlantUML source path: {SourcePath}", request.PlantUmlSourcePath);
+        logger.LogInformation("Output directory: {Directory}", request.Directory);
+
+        // Resolve full paths
+        var sourcePath = Path.GetFullPath(request.PlantUmlSourcePath);
+        var outputDirectory = Path.GetFullPath(request.Directory);
+
+        // Validate the PlantUML files
+        var validationResult = await validationService.ValidateDirectoryAsync(sourcePath, cancellationToken);
+
+        // Generate the markdown report
+        var reportContent = validationResult.ToMarkdownReport();
+
+        // Determine the report filename
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+        var reportName = string.IsNullOrWhiteSpace(request.Name)
+            ? $"plantuml-validation-report-{timestamp}.md"
+            : $"{SanitizeFileName(request.Name)}-validation-report-{timestamp}.md";
+
+        var reportPath = Path.Combine(outputDirectory, reportName);
+
+        // Ensure output directory exists
+        if (!System.IO.Directory.Exists(outputDirectory))
+        {
+            System.IO.Directory.CreateDirectory(outputDirectory);
+        }
+
+        // Write the report
+        await File.WriteAllTextAsync(reportPath, reportContent, cancellationToken);
+
+        logger.LogInformation("Validation report saved to: {ReportPath}", reportPath);
+
+        // Log summary to console
+        LogValidationSummary(validationResult);
+
+        if (validationResult.IsValid)
+        {
+            logger.LogInformation("Validation PASSED - PlantUML files are valid for solution generation");
+        }
+        else
+        {
+            logger.LogWarning("Validation FAILED - Found {ErrorCount} error(s) and {WarningCount} warning(s)",
+                validationResult.TotalErrors, validationResult.TotalWarnings);
+            logger.LogWarning("Review the validation report at: {ReportPath}", reportPath);
+        }
+    }
+
+    private void LogValidationSummary(DotNet.Artifacts.PlantUml.Models.PlantUmlValidationResult result)
+    {
+        logger.LogInformation("========================================");
+        logger.LogInformation("VALIDATION SUMMARY");
+        logger.LogInformation("========================================");
+        logger.LogInformation("Source Path: {SourcePath}", result.SourcePath);
+        logger.LogInformation("Documents Analyzed: {Count}", result.DocumentResults.Count);
+        logger.LogInformation("Status: {Status}", result.IsValid ? "PASSED" : "FAILED");
+        logger.LogInformation("----------------------------------------");
+        logger.LogInformation("Errors:   {Count}", result.TotalErrors);
+        logger.LogInformation("Warnings: {Count}", result.TotalWarnings);
+        logger.LogInformation("Info:     {Count}", result.TotalInfo);
+        logger.LogInformation("========================================");
+
+        // Log global issues (errors first)
+        if (result.GlobalIssues.Count > 0)
+        {
+            logger.LogInformation("Global Issues:");
+            foreach (var issue in result.GlobalIssues)
+            {
+                var logLevel = issue.Severity switch
+                {
+                    DotNet.Artifacts.PlantUml.Models.ValidationSeverity.Error => LogLevel.Error,
+                    DotNet.Artifacts.PlantUml.Models.ValidationSeverity.Warning => LogLevel.Warning,
+                    _ => LogLevel.Information
+                };
+
+                logger.Log(logLevel, "[{Severity}] {Code}: {Message}",
+                    issue.Severity, issue.Code, issue.Message);
+            }
+        }
+
+        // Log document-level summaries
+        foreach (var docResult in result.DocumentResults)
+        {
+            if (docResult.HasErrors || docResult.HasWarnings)
+            {
+                var fileName = Path.GetFileName(docResult.FilePath);
+                logger.LogInformation("Document: {FileName} - Errors: {Errors}, Warnings: {Warnings}",
+                    fileName, docResult.ErrorCount, docResult.WarningCount);
+            }
+        }
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var sanitized = new string(name.Select(c => invalidChars.Contains(c) ? '_' : c).ToArray());
+        return sanitized.ToLowerInvariant().Replace(' ', '-');
     }
 }

--- a/src/Endpoint.DotNet/Artifacts/PlantUml/Models/PlantUmlValidationResult.cs
+++ b/src/Endpoint.DotNet/Artifacts/PlantUml/Models/PlantUmlValidationResult.cs
@@ -1,0 +1,585 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Endpoint.DotNet.Artifacts.PlantUml.Models;
+
+/// <summary>
+/// Represents the overall validation result for a PlantUML solution architecture.
+/// </summary>
+public class PlantUmlValidationResult
+{
+    public PlantUmlValidationResult()
+    {
+        DocumentResults = [];
+        GlobalIssues = [];
+    }
+
+    /// <summary>
+    /// Gets or sets the source directory path that was validated.
+    /// </summary>
+    public string SourcePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when validation was performed.
+    /// </summary>
+    public DateTime ValidatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Gets or sets the validation results for each document.
+    /// </summary>
+    public List<PlantUmlDocumentValidationResult> DocumentResults { get; set; }
+
+    /// <summary>
+    /// Gets or sets issues that span multiple documents or are solution-wide.
+    /// </summary>
+    public List<PlantUmlValidationIssue> GlobalIssues { get; set; }
+
+    /// <summary>
+    /// Gets whether all validation passed with no errors.
+    /// </summary>
+    public bool IsValid => !HasErrors;
+
+    /// <summary>
+    /// Gets whether there are any error-level issues.
+    /// </summary>
+    public bool HasErrors => GlobalIssues.Any(i => i.Severity == ValidationSeverity.Error) ||
+                            DocumentResults.Any(d => d.HasErrors);
+
+    /// <summary>
+    /// Gets whether there are any warning-level issues.
+    /// </summary>
+    public bool HasWarnings => GlobalIssues.Any(i => i.Severity == ValidationSeverity.Warning) ||
+                              DocumentResults.Any(d => d.HasWarnings);
+
+    /// <summary>
+    /// Gets the total number of errors across all documents.
+    /// </summary>
+    public int TotalErrors => GlobalIssues.Count(i => i.Severity == ValidationSeverity.Error) +
+                             DocumentResults.Sum(d => d.ErrorCount);
+
+    /// <summary>
+    /// Gets the total number of warnings across all documents.
+    /// </summary>
+    public int TotalWarnings => GlobalIssues.Count(i => i.Severity == ValidationSeverity.Warning) +
+                               DocumentResults.Sum(d => d.WarningCount);
+
+    /// <summary>
+    /// Gets the total number of info-level issues across all documents.
+    /// </summary>
+    public int TotalInfo => GlobalIssues.Count(i => i.Severity == ValidationSeverity.Info) +
+                           DocumentResults.Sum(d => d.InfoCount);
+
+    /// <summary>
+    /// Generates a detailed markdown report of the validation results.
+    /// </summary>
+    public string ToMarkdownReport()
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("# PlantUML Solution Architecture Validation Report");
+        sb.AppendLine();
+        sb.AppendLine("## Summary");
+        sb.AppendLine();
+        sb.AppendLine($"- **Source Path:** `{SourcePath}`");
+        sb.AppendLine($"- **Validated At:** {ValidatedAt:yyyy-MM-dd HH:mm:ss} UTC");
+        sb.AppendLine($"- **Overall Status:** {(IsValid ? "PASSED" : "FAILED")}");
+        sb.AppendLine($"- **Documents Analyzed:** {DocumentResults.Count}");
+        sb.AppendLine();
+
+        // Statistics table
+        sb.AppendLine("### Issue Statistics");
+        sb.AppendLine();
+        sb.AppendLine("| Severity | Count |");
+        sb.AppendLine("|----------|-------|");
+        sb.AppendLine($"| Errors | {TotalErrors} |");
+        sb.AppendLine($"| Warnings | {TotalWarnings} |");
+        sb.AppendLine($"| Info | {TotalInfo} |");
+        sb.AppendLine();
+
+        // Global issues section
+        if (GlobalIssues.Count > 0)
+        {
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.AppendLine("## Global Issues");
+            sb.AppendLine();
+            sb.AppendLine("Issues that affect the entire solution or span multiple documents.");
+            sb.AppendLine();
+
+            var errorIssues = GlobalIssues.Where(i => i.Severity == ValidationSeverity.Error).ToList();
+            var warningIssues = GlobalIssues.Where(i => i.Severity == ValidationSeverity.Warning).ToList();
+            var infoIssues = GlobalIssues.Where(i => i.Severity == ValidationSeverity.Info).ToList();
+
+            if (errorIssues.Count > 0)
+            {
+                sb.AppendLine("### Errors");
+                sb.AppendLine();
+                foreach (var issue in errorIssues)
+                {
+                    sb.AppendLine(issue.ToMarkdown());
+                }
+
+                sb.AppendLine();
+            }
+
+            if (warningIssues.Count > 0)
+            {
+                sb.AppendLine("### Warnings");
+                sb.AppendLine();
+                foreach (var issue in warningIssues)
+                {
+                    sb.AppendLine(issue.ToMarkdown());
+                }
+
+                sb.AppendLine();
+            }
+
+            if (infoIssues.Count > 0)
+            {
+                sb.AppendLine("### Information");
+                sb.AppendLine();
+                foreach (var issue in infoIssues)
+                {
+                    sb.AppendLine(issue.ToMarkdown());
+                }
+
+                sb.AppendLine();
+            }
+        }
+
+        // Per-document results
+        if (DocumentResults.Count > 0)
+        {
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.AppendLine("## Document Validation Results");
+            sb.AppendLine();
+
+            foreach (var docResult in DocumentResults.OrderByDescending(d => d.ErrorCount).ThenByDescending(d => d.WarningCount))
+            {
+                sb.AppendLine(docResult.ToMarkdown());
+                sb.AppendLine();
+            }
+        }
+
+        // How to fix section
+        if (HasErrors || HasWarnings)
+        {
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.AppendLine("## How to Fix Issues");
+            sb.AppendLine();
+            sb.AppendLine("Please review the issues listed above and make the necessary corrections to your PlantUML files.");
+            sb.AppendLine("Once fixed, re-run the validation command to ensure all issues are resolved.");
+            sb.AppendLine();
+            sb.AppendLine("For more information on the PlantUML scaffolding specification, refer to:");
+            sb.AppendLine("`docs/specs/plantuml-scaffolding.spec`");
+            sb.AppendLine();
+        }
+        else
+        {
+            sb.AppendLine("---");
+            sb.AppendLine();
+            sb.AppendLine("## Next Steps");
+            sb.AppendLine();
+            sb.AppendLine("All validation checks passed! You can now generate a solution from these PlantUML files using:");
+            sb.AppendLine();
+            sb.AppendLine("```bash");
+            sb.AppendLine("endpoint solution-create-from-plant-uml -n <SolutionName> -p <PlantUmlSourcePath>");
+            sb.AppendLine("```");
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Represents validation results for a single PlantUML document.
+/// </summary>
+public class PlantUmlDocumentValidationResult
+{
+    public PlantUmlDocumentValidationResult()
+    {
+        Issues = [];
+        EntityResults = [];
+    }
+
+    /// <summary>
+    /// Gets or sets the file path of the document.
+    /// </summary>
+    public string FilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the document title.
+    /// </summary>
+    public string DocumentTitle { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of validation issues for this document.
+    /// </summary>
+    public List<PlantUmlValidationIssue> Issues { get; set; }
+
+    /// <summary>
+    /// Gets or sets detailed validation results for each entity in the document.
+    /// </summary>
+    public List<PlantUmlEntityValidationResult> EntityResults { get; set; }
+
+    /// <summary>
+    /// Gets whether the document has any errors.
+    /// </summary>
+    public bool HasErrors => Issues.Any(i => i.Severity == ValidationSeverity.Error) ||
+                            EntityResults.Any(e => e.HasErrors);
+
+    /// <summary>
+    /// Gets whether the document has any warnings.
+    /// </summary>
+    public bool HasWarnings => Issues.Any(i => i.Severity == ValidationSeverity.Warning) ||
+                              EntityResults.Any(e => e.HasWarnings);
+
+    /// <summary>
+    /// Gets the error count for this document.
+    /// </summary>
+    public int ErrorCount => Issues.Count(i => i.Severity == ValidationSeverity.Error) +
+                            EntityResults.Sum(e => e.ErrorCount);
+
+    /// <summary>
+    /// Gets the warning count for this document.
+    /// </summary>
+    public int WarningCount => Issues.Count(i => i.Severity == ValidationSeverity.Warning) +
+                              EntityResults.Sum(e => e.WarningCount);
+
+    /// <summary>
+    /// Gets the info count for this document.
+    /// </summary>
+    public int InfoCount => Issues.Count(i => i.Severity == ValidationSeverity.Info) +
+                           EntityResults.Sum(e => e.InfoCount);
+
+    public string ToMarkdown()
+    {
+        var sb = new StringBuilder();
+
+        var statusIcon = !HasErrors && !HasWarnings ? "[PASS]" : (HasErrors ? "[FAIL]" : "[WARN]");
+        var fileName = System.IO.Path.GetFileName(FilePath);
+
+        sb.AppendLine($"### {statusIcon} `{fileName}`");
+        sb.AppendLine();
+        sb.AppendLine($"**Path:** `{FilePath}`");
+
+        if (!string.IsNullOrEmpty(DocumentTitle))
+        {
+            sb.AppendLine($"**Title:** {DocumentTitle}");
+        }
+
+        sb.AppendLine();
+
+        if (!HasErrors && !HasWarnings && Issues.Count == 0 && EntityResults.All(e => e.Issues.Count == 0))
+        {
+            sb.AppendLine("No issues found.");
+            return sb.ToString();
+        }
+
+        // Document-level issues
+        var docErrors = Issues.Where(i => i.Severity == ValidationSeverity.Error).ToList();
+        var docWarnings = Issues.Where(i => i.Severity == ValidationSeverity.Warning).ToList();
+        var docInfo = Issues.Where(i => i.Severity == ValidationSeverity.Info).ToList();
+
+        if (docErrors.Count > 0)
+        {
+            sb.AppendLine("#### Document Errors");
+            sb.AppendLine();
+            foreach (var issue in docErrors)
+            {
+                sb.AppendLine(issue.ToMarkdown());
+            }
+
+            sb.AppendLine();
+        }
+
+        if (docWarnings.Count > 0)
+        {
+            sb.AppendLine("#### Document Warnings");
+            sb.AppendLine();
+            foreach (var issue in docWarnings)
+            {
+                sb.AppendLine(issue.ToMarkdown());
+            }
+
+            sb.AppendLine();
+        }
+
+        if (docInfo.Count > 0)
+        {
+            sb.AppendLine("#### Document Information");
+            sb.AppendLine();
+            foreach (var issue in docInfo)
+            {
+                sb.AppendLine(issue.ToMarkdown());
+            }
+
+            sb.AppendLine();
+        }
+
+        // Entity-level issues
+        var entitiesWithIssues = EntityResults.Where(e => e.Issues.Count > 0).ToList();
+        if (entitiesWithIssues.Count > 0)
+        {
+            sb.AppendLine("#### Entity Issues");
+            sb.AppendLine();
+            foreach (var entity in entitiesWithIssues)
+            {
+                sb.AppendLine(entity.ToMarkdown());
+            }
+        }
+
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Represents validation results for a specific entity (class/enum).
+/// </summary>
+public class PlantUmlEntityValidationResult
+{
+    public PlantUmlEntityValidationResult()
+    {
+        Issues = [];
+    }
+
+    /// <summary>
+    /// Gets or sets the entity name.
+    /// </summary>
+    public string EntityName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the entity type (class, enum, etc.).
+    /// </summary>
+    public string EntityType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the namespace/package of the entity.
+    /// </summary>
+    public string Namespace { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of validation issues for this entity.
+    /// </summary>
+    public List<PlantUmlValidationIssue> Issues { get; set; }
+
+    /// <summary>
+    /// Gets whether the entity has any errors.
+    /// </summary>
+    public bool HasErrors => Issues.Any(i => i.Severity == ValidationSeverity.Error);
+
+    /// <summary>
+    /// Gets whether the entity has any warnings.
+    /// </summary>
+    public bool HasWarnings => Issues.Any(i => i.Severity == ValidationSeverity.Warning);
+
+    /// <summary>
+    /// Gets the error count for this entity.
+    /// </summary>
+    public int ErrorCount => Issues.Count(i => i.Severity == ValidationSeverity.Error);
+
+    /// <summary>
+    /// Gets the warning count for this entity.
+    /// </summary>
+    public int WarningCount => Issues.Count(i => i.Severity == ValidationSeverity.Warning);
+
+    /// <summary>
+    /// Gets the info count for this entity.
+    /// </summary>
+    public int InfoCount => Issues.Count(i => i.Severity == ValidationSeverity.Info);
+
+    public string ToMarkdown()
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine($"**{EntityType}: `{EntityName}`**");
+
+        if (!string.IsNullOrEmpty(Namespace))
+        {
+            sb.AppendLine($"  - Namespace: `{Namespace}`");
+        }
+
+        sb.AppendLine();
+
+        foreach (var issue in Issues.OrderBy(i => i.Severity))
+        {
+            sb.AppendLine($"  {issue.ToMarkdown()}");
+        }
+
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Represents a single validation issue.
+/// </summary>
+public class PlantUmlValidationIssue
+{
+    /// <summary>
+    /// Gets or sets the issue code for categorization.
+    /// </summary>
+    public string Code { get; set; }
+
+    /// <summary>
+    /// Gets or sets the severity of the issue.
+    /// </summary>
+    public ValidationSeverity Severity { get; set; }
+
+    /// <summary>
+    /// Gets or sets the category of the issue.
+    /// </summary>
+    public ValidationCategory Category { get; set; }
+
+    /// <summary>
+    /// Gets or sets the issue message.
+    /// </summary>
+    public string Message { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional details or context for the issue.
+    /// </summary>
+    public string Details { get; set; }
+
+    /// <summary>
+    /// Gets or sets the suggested fix for the issue.
+    /// </summary>
+    public string SuggestedFix { get; set; }
+
+    /// <summary>
+    /// Gets or sets the line number where the issue was found (if applicable).
+    /// </summary>
+    public int? LineNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the related element name (class, property, etc.).
+    /// </summary>
+    public string RelatedElement { get; set; }
+
+    public string ToMarkdown()
+    {
+        var severityIcon = Severity switch
+        {
+            ValidationSeverity.Error => "ERROR",
+            ValidationSeverity.Warning => "WARNING",
+            ValidationSeverity.Info => "INFO",
+            _ => "?"
+        };
+
+        var sb = new StringBuilder();
+        sb.Append($"- **[{severityIcon}]** `{Code}`: {Message}");
+
+        if (!string.IsNullOrEmpty(RelatedElement))
+        {
+            sb.Append($" (Element: `{RelatedElement}`)");
+        }
+
+        if (LineNumber.HasValue)
+        {
+            sb.Append($" [Line {LineNumber}]");
+        }
+
+        if (!string.IsNullOrEmpty(Details))
+        {
+            sb.AppendLine();
+            sb.Append($"  - Details: {Details}");
+        }
+
+        if (!string.IsNullOrEmpty(SuggestedFix))
+        {
+            sb.AppendLine();
+            sb.Append($"  - Fix: {SuggestedFix}");
+        }
+
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Validation severity levels.
+/// </summary>
+public enum ValidationSeverity
+{
+    /// <summary>
+    /// Informational message - does not prevent solution generation.
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// Warning - may cause issues but does not prevent solution generation.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// Error - prevents successful solution generation.
+    /// </summary>
+    Error
+}
+
+/// <summary>
+/// Categories for validation issues.
+/// </summary>
+public enum ValidationCategory
+{
+    /// <summary>
+    /// Document structure issues (missing @startuml/@enduml, etc.).
+    /// </summary>
+    DocumentStructure,
+
+    /// <summary>
+    /// Missing required documents.
+    /// </summary>
+    MissingDocument,
+
+    /// <summary>
+    /// Entity definition issues.
+    /// </summary>
+    EntityDefinition,
+
+    /// <summary>
+    /// Property definition issues.
+    /// </summary>
+    PropertyDefinition,
+
+    /// <summary>
+    /// Type reference issues.
+    /// </summary>
+    TypeReference,
+
+    /// <summary>
+    /// Relationship definition issues.
+    /// </summary>
+    Relationship,
+
+    /// <summary>
+    /// Namespace/package naming issues.
+    /// </summary>
+    Naming,
+
+    /// <summary>
+    /// Stereotype issues.
+    /// </summary>
+    Stereotype,
+
+    /// <summary>
+    /// Duplicate definitions.
+    /// </summary>
+    Duplicate,
+
+    /// <summary>
+    /// Consistency issues between documents.
+    /// </summary>
+    Consistency,
+
+    /// <summary>
+    /// Best practice recommendations.
+    /// </summary>
+    BestPractice
+}

--- a/src/Endpoint.DotNet/Artifacts/PlantUml/Services/IPlantUmlValidationService.cs
+++ b/src/Endpoint.DotNet/Artifacts/PlantUml/Services/IPlantUmlValidationService.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Endpoint.DotNet.Artifacts.PlantUml.Models;
+
+namespace Endpoint.DotNet.Artifacts.PlantUml.Services;
+
+/// <summary>
+/// Service for validating PlantUML solution architecture files against the specification.
+/// </summary>
+public interface IPlantUmlValidationService
+{
+    /// <summary>
+    /// Validates all PlantUML files in the specified directory against the PlantUML scaffolding specification.
+    /// </summary>
+    /// <param name="directoryPath">The path to the directory containing PlantUML files.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A comprehensive validation result with all issues found.</returns>
+    Task<PlantUmlValidationResult> ValidateDirectoryAsync(string directoryPath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates a single PlantUML file against the PlantUML scaffolding specification.
+    /// </summary>
+    /// <param name="filePath">The path to the PlantUML file.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A validation result for the document.</returns>
+    Task<PlantUmlDocumentValidationResult> ValidateFileAsync(string filePath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates a parsed PlantUML solution model.
+    /// </summary>
+    /// <param name="model">The parsed PlantUML solution model.</param>
+    /// <returns>A comprehensive validation result with all issues found.</returns>
+    PlantUmlValidationResult ValidateModel(PlantUmlSolutionModel model);
+}

--- a/src/Endpoint.DotNet/Artifacts/PlantUml/Services/PlantUmlValidationService.cs
+++ b/src/Endpoint.DotNet/Artifacts/PlantUml/Services/PlantUmlValidationService.cs
@@ -1,0 +1,1077 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Endpoint.DotNet.Artifacts.PlantUml.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.DotNet.Artifacts.PlantUml.Services;
+
+/// <summary>
+/// Implementation of the PlantUML validation service that validates files against the PlantUML scaffolding specification.
+/// </summary>
+public class PlantUmlValidationService : IPlantUmlValidationService
+{
+    private readonly ILogger<PlantUmlValidationService> logger;
+    private readonly IPlantUmlParserService parserService;
+    private readonly IFileSystem fileSystem;
+
+    /// <summary>
+    /// Required document files as specified in the PlantUML scaffolding specification.
+    /// </summary>
+    private static readonly HashSet<string> RequiredDocuments = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "solution-architecture.puml",
+        "domain-models.puml",
+        "cqrs-pattern.puml",
+        "api-endpoints.puml",
+        "database-architecture.puml",
+        "authentication-flow.puml",
+        "angular-architecture.puml",
+        "angular-routing.puml",
+        "angular-http.puml"
+    };
+
+    /// <summary>
+    /// Recommended (but not required) document files.
+    /// </summary>
+    private static readonly HashSet<string> RecommendedDocuments = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "solution-architecture.puml",
+        "domain-models.puml"
+    };
+
+    /// <summary>
+    /// Valid primitive types recognized by the scaffolder.
+    /// </summary>
+    private static readonly HashSet<string> ValidPrimitiveTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "string", "int", "long", "decimal", "double", "float", "bool", "boolean",
+        "DateTime", "DateTimeOffset", "Guid", "byte", "short", "char",
+        "void", "object", "dynamic"
+    };
+
+    /// <summary>
+    /// Valid collection type wrappers.
+    /// </summary>
+    private static readonly HashSet<string> ValidCollectionTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "List", "IList", "ICollection", "IEnumerable", "Collection", "HashSet", "ISet",
+        "Dictionary", "IDictionary", "Array"
+    };
+
+    /// <summary>
+    /// Valid stereotypes as defined in the specification.
+    /// </summary>
+    private static readonly HashSet<string> ValidStereotypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "aggregate", "entity", "valueobject", "enum", "service"
+    };
+
+    /// <summary>
+    /// Audit field names that should be automatically generated.
+    /// </summary>
+    private static readonly HashSet<string> AuditFields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CreatedAt", "ModifiedAt", "CreatedBy", "ModifiedBy"
+    };
+
+    public PlantUmlValidationService(
+        ILogger<PlantUmlValidationService> logger,
+        IPlantUmlParserService parserService,
+        IFileSystem fileSystem)
+    {
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.parserService = parserService ?? throw new ArgumentNullException(nameof(parserService));
+        this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+    }
+
+    public async Task<PlantUmlValidationResult> ValidateDirectoryAsync(string directoryPath, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Validating PlantUML files in directory: {Directory}", directoryPath);
+
+        var result = new PlantUmlValidationResult
+        {
+            SourcePath = directoryPath,
+            ValidatedAt = DateTime.UtcNow
+        };
+
+        // Check if directory exists
+        if (!fileSystem.Directory.Exists(directoryPath))
+        {
+            result.GlobalIssues.Add(new PlantUmlValidationIssue
+            {
+                Code = "DIR001",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.DocumentStructure,
+                Message = "PlantUML source directory does not exist",
+                Details = $"Directory not found: {directoryPath}",
+                SuggestedFix = "Ensure the directory path is correct and the directory exists"
+            });
+            return result;
+        }
+
+        // Parse all PlantUML files
+        var model = await parserService.ParseDirectoryAsync(directoryPath, cancellationToken);
+
+        // Validate the parsed model
+        var modelValidation = ValidateModel(model);
+
+        // Merge results
+        result.DocumentResults.AddRange(modelValidation.DocumentResults);
+        result.GlobalIssues.AddRange(modelValidation.GlobalIssues);
+
+        // Additional file-level validations (raw content checks)
+        await ValidateRawFileContentsAsync(directoryPath, result, cancellationToken);
+
+        logger.LogInformation("Validation complete. Errors: {Errors}, Warnings: {Warnings}",
+            result.TotalErrors, result.TotalWarnings);
+
+        return result;
+    }
+
+    public async Task<PlantUmlDocumentValidationResult> ValidateFileAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Validating PlantUML file: {File}", filePath);
+
+        var result = new PlantUmlDocumentValidationResult
+        {
+            FilePath = filePath
+        };
+
+        if (!fileSystem.File.Exists(filePath))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "FILE001",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.DocumentStructure,
+                Message = "PlantUML file does not exist",
+                Details = $"File not found: {filePath}"
+            });
+            return result;
+        }
+
+        var content = await Task.Run(() => fileSystem.File.ReadAllText(filePath), cancellationToken);
+        ValidateRawContent(content, filePath, result);
+
+        var document = await parserService.ParseFileAsync(filePath, cancellationToken);
+        if (document != null)
+        {
+            result.DocumentTitle = document.Title;
+            ValidateDocument(document, result);
+        }
+
+        return result;
+    }
+
+    public PlantUmlValidationResult ValidateModel(PlantUmlSolutionModel model)
+    {
+        var result = new PlantUmlValidationResult
+        {
+            SourcePath = model.SourcePath,
+            ValidatedAt = DateTime.UtcNow
+        };
+
+        // Validate required documents
+        ValidateRequiredDocuments(model, result);
+
+        // Validate each document
+        foreach (var document in model.Documents)
+        {
+            var docResult = new PlantUmlDocumentValidationResult
+            {
+                FilePath = document.FilePath,
+                DocumentTitle = document.Title
+            };
+
+            ValidateDocument(document, docResult);
+            result.DocumentResults.Add(docResult);
+        }
+
+        // Cross-document validations
+        ValidateCrossDocumentConsistency(model, result);
+
+        return result;
+    }
+
+    private void ValidateRequiredDocuments(PlantUmlSolutionModel model, PlantUmlValidationResult result)
+    {
+        var existingFiles = model.Documents
+            .Where(d => !string.IsNullOrEmpty(d.FilePath))
+            .Select(d => Path.GetFileName(d.FilePath))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Check for domain-models.puml - this is critical
+        if (!existingFiles.Any(f => f.Contains("domain", StringComparison.OrdinalIgnoreCase) &&
+                                   f.EndsWith(".puml", StringComparison.OrdinalIgnoreCase)))
+        {
+            // Check if there are any entities defined
+            if (!model.GetAllClasses().Any())
+            {
+                result.GlobalIssues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "REQ001",
+                    Severity = ValidationSeverity.Error,
+                    Category = ValidationCategory.MissingDocument,
+                    Message = "No domain models found",
+                    Details = "No classes or entities were found in any PlantUML files. At least one aggregate or entity must be defined.",
+                    SuggestedFix = "Create a domain-models.puml file with at least one class definition using the <<aggregate>> or <<entity>> stereotype"
+                });
+            }
+        }
+
+        // Check for recommended documents (warnings, not errors)
+        foreach (var recommended in RecommendedDocuments)
+        {
+            if (!existingFiles.Contains(recommended))
+            {
+                result.GlobalIssues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "REC001",
+                    Severity = ValidationSeverity.Info,
+                    Category = ValidationCategory.MissingDocument,
+                    Message = $"Recommended document not found: {recommended}",
+                    Details = $"The file '{recommended}' is recommended for a complete solution architecture but is optional.",
+                    SuggestedFix = $"Consider creating '{recommended}' for better documentation"
+                });
+            }
+        }
+
+        // Check if at least one document was found
+        if (model.Documents.Count == 0)
+        {
+            result.GlobalIssues.Add(new PlantUmlValidationIssue
+            {
+                Code = "REQ002",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.MissingDocument,
+                Message = "No PlantUML documents found",
+                Details = "The specified directory contains no .puml files",
+                SuggestedFix = "Add at least one .puml file with entity definitions to the directory"
+            });
+        }
+    }
+
+    private void ValidateDocument(PlantUmlDocumentModel document, PlantUmlDocumentValidationResult result)
+    {
+        // Validate all classes
+        foreach (var package in document.Packages)
+        {
+            ValidatePackage(package, result);
+        }
+
+        foreach (var cls in document.Classes)
+        {
+            var entityResult = ValidateClass(cls, document);
+            if (entityResult.Issues.Count > 0)
+            {
+                result.EntityResults.Add(entityResult);
+            }
+        }
+
+        foreach (var enm in document.Enums)
+        {
+            var entityResult = ValidateEnum(enm);
+            if (entityResult.Issues.Count > 0)
+            {
+                result.EntityResults.Add(entityResult);
+            }
+        }
+
+        // Validate relationships
+        ValidateRelationships(document, result);
+
+        // Validate components
+        ValidateComponents(document, result);
+    }
+
+    private void ValidatePackage(PlantUmlPackageModel package, PlantUmlDocumentValidationResult result)
+    {
+        // Validate package naming convention
+        if (!string.IsNullOrEmpty(package.Name))
+        {
+            var parts = package.Name.Split('.');
+
+            // Should follow: {SolutionName}.{BoundedContext}.Aggregates.{EntityName} or {SolutionName}.Aggregates.{EntityName}
+            if (!parts.Any(p => p.Equals("Aggregates", StringComparison.OrdinalIgnoreCase)))
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "PKG001",
+                    Severity = ValidationSeverity.Warning,
+                    Category = ValidationCategory.Naming,
+                    Message = "Package name does not follow expected convention",
+                    Details = $"Package '{package.Name}' should include 'Aggregates' segment (e.g., 'SolutionName.Aggregates.EntityName' or 'SolutionName.BoundedContext.Aggregates.EntityName')",
+                    SuggestedFix = "Rename the package to follow the pattern: {SolutionName}[.{BoundedContext}].Aggregates.{EntityName}",
+                    RelatedElement = package.Name
+                });
+            }
+
+            // Validate classes within package
+            foreach (var cls in package.Classes)
+            {
+                var entityResult = ValidateClass(cls, null);
+                if (entityResult.Issues.Count > 0)
+                {
+                    result.EntityResults.Add(entityResult);
+                }
+            }
+
+            // Validate enums within package
+            foreach (var enm in package.Enums)
+            {
+                var entityResult = ValidateEnum(enm);
+                if (entityResult.Issues.Count > 0)
+                {
+                    result.EntityResults.Add(entityResult);
+                }
+            }
+        }
+    }
+
+    private PlantUmlEntityValidationResult ValidateClass(PlantUmlClassModel cls, PlantUmlDocumentModel document)
+    {
+        var result = new PlantUmlEntityValidationResult
+        {
+            EntityName = cls.Name,
+            EntityType = cls.Stereotype == PlantUmlStereotype.None ? "Class" : cls.Stereotype.ToString(),
+            Namespace = cls.Namespace
+        };
+
+        // Validate class name
+        if (string.IsNullOrWhiteSpace(cls.Name))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "CLS001",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.EntityDefinition,
+                Message = "Class has no name",
+                SuggestedFix = "Provide a valid class name"
+            });
+            return result;
+        }
+
+        // Validate class name is PascalCase
+        if (!char.IsUpper(cls.Name[0]))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "CLS002",
+                Severity = ValidationSeverity.Warning,
+                Category = ValidationCategory.Naming,
+                Message = "Class name should start with uppercase letter (PascalCase)",
+                Details = $"Class name '{cls.Name}' starts with lowercase",
+                SuggestedFix = $"Rename to '{char.ToUpper(cls.Name[0])}{cls.Name[1..]}'",
+                RelatedElement = cls.Name
+            });
+        }
+
+        // For aggregates and entities, validate primary key
+        if (cls.IsAggregate || cls.IsEntity)
+        {
+            ValidateEntityPrimaryKey(cls, result);
+            ValidateEntityProperties(cls, result);
+        }
+
+        // Validate stereotype if present
+        if (cls.Stereotype != PlantUmlStereotype.None)
+        {
+            // Stereotype is already validated by the parser, but we can add additional checks
+        }
+
+        // Validate all properties
+        foreach (var prop in cls.Properties)
+        {
+            ValidateProperty(prop, cls.Name, result);
+        }
+
+        // Check for empty class
+        if (cls.Properties.Count == 0 && cls.Methods.Count == 0)
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "CLS003",
+                Severity = ValidationSeverity.Warning,
+                Category = ValidationCategory.EntityDefinition,
+                Message = "Class has no properties or methods",
+                Details = $"Class '{cls.Name}' is empty",
+                SuggestedFix = "Add at least one property to the class",
+                RelatedElement = cls.Name
+            });
+        }
+
+        return result;
+    }
+
+    private void ValidateEntityPrimaryKey(PlantUmlClassModel cls, PlantUmlEntityValidationResult result)
+    {
+        var expectedKeyName = $"{cls.Name}Id";
+        var keyProperty = cls.Properties.FirstOrDefault(p => p.IsKey);
+
+        if (keyProperty == null)
+        {
+            // Check if there's a property that looks like a key but wasn't detected
+            var possibleKey = cls.Properties.FirstOrDefault(p =>
+                p.Name.Equals(expectedKeyName, StringComparison.OrdinalIgnoreCase));
+
+            if (possibleKey == null)
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "KEY001",
+                    Severity = ValidationSeverity.Error,
+                    Category = ValidationCategory.EntityDefinition,
+                    Message = $"Entity is missing required primary key property",
+                    Details = $"Entity '{cls.Name}' must have a property named '{expectedKeyName}' of type 'string'",
+                    SuggestedFix = $"Add property: +{expectedKeyName} : string",
+                    RelatedElement = cls.Name
+                });
+            }
+            else
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "KEY002",
+                    Severity = ValidationSeverity.Warning,
+                    Category = ValidationCategory.EntityDefinition,
+                    Message = "Primary key property found but not marked as key",
+                    Details = $"Property '{possibleKey.Name}' appears to be the primary key but was not recognized",
+                    SuggestedFix = "Ensure the property follows the format: +{ClassName}Id : string",
+                    RelatedElement = possibleKey.Name
+                });
+            }
+        }
+        else if (!keyProperty.Name.Equals(expectedKeyName, StringComparison.OrdinalIgnoreCase))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "KEY003",
+                Severity = ValidationSeverity.Warning,
+                Category = ValidationCategory.Naming,
+                Message = "Primary key property does not follow naming convention",
+                Details = $"Expected '{expectedKeyName}' but found '{keyProperty.Name}'",
+                SuggestedFix = $"Rename the property to '{expectedKeyName}'",
+                RelatedElement = keyProperty.Name
+            });
+        }
+
+        // Validate key type is string
+        if (keyProperty != null && !keyProperty.Type.Equals("string", StringComparison.OrdinalIgnoreCase) &&
+            !keyProperty.Type.Equals("Guid", StringComparison.OrdinalIgnoreCase))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "KEY004",
+                Severity = ValidationSeverity.Warning,
+                Category = ValidationCategory.PropertyDefinition,
+                Message = "Primary key should be of type 'string' or 'Guid'",
+                Details = $"Property '{keyProperty.Name}' is of type '{keyProperty.Type}'",
+                SuggestedFix = "Change the property type to 'string'",
+                RelatedElement = keyProperty.Name
+            });
+        }
+    }
+
+    private void ValidateEntityProperties(PlantUmlClassModel cls, PlantUmlEntityValidationResult result)
+    {
+        // Check for audit fields (info, not required)
+        var hasCreatedAt = cls.Properties.Any(p => p.Name.Equals("CreatedAt", StringComparison.OrdinalIgnoreCase));
+        var hasModifiedAt = cls.Properties.Any(p => p.Name.Equals("ModifiedAt", StringComparison.OrdinalIgnoreCase));
+
+        if (!hasCreatedAt || !hasModifiedAt)
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "AUD001",
+                Severity = ValidationSeverity.Info,
+                Category = ValidationCategory.BestPractice,
+                Message = "Entity is missing audit fields",
+                Details = "Audit fields (CreatedAt, ModifiedAt) are recommended for tracking entity changes. They will be automatically added during scaffolding.",
+                SuggestedFix = "Consider adding: +CreatedAt : DateTime and +ModifiedAt : DateTime",
+                RelatedElement = cls.Name
+            });
+        }
+    }
+
+    private void ValidateProperty(PlantUmlPropertyModel prop, string className, PlantUmlEntityValidationResult result)
+    {
+        // Validate property name
+        if (string.IsNullOrWhiteSpace(prop.Name))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "PROP001",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.PropertyDefinition,
+                Message = "Property has no name",
+                SuggestedFix = "Provide a valid property name",
+                RelatedElement = className
+            });
+            return;
+        }
+
+        // Validate property name is PascalCase
+        if (!char.IsUpper(prop.Name[0]))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "PROP002",
+                Severity = ValidationSeverity.Warning,
+                Category = ValidationCategory.Naming,
+                Message = "Property name should start with uppercase letter (PascalCase)",
+                Details = $"Property '{prop.Name}' starts with lowercase",
+                SuggestedFix = $"Rename to '{char.ToUpper(prop.Name[0])}{prop.Name[1..]}'",
+                RelatedElement = prop.Name
+            });
+        }
+
+        // Validate type is specified
+        if (string.IsNullOrWhiteSpace(prop.Type) && string.IsNullOrWhiteSpace(prop.CollectionType))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "PROP003",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.PropertyDefinition,
+                Message = "Property has no type specified",
+                Details = $"Property '{prop.Name}' is missing type annotation",
+                SuggestedFix = $"Add type annotation: +{prop.Name} : TypeName",
+                RelatedElement = prop.Name
+            });
+        }
+
+        // Validate collection types
+        if (prop.IsCollection && !string.IsNullOrEmpty(prop.CollectionType))
+        {
+            if (!ValidCollectionTypes.Contains(prop.CollectionType))
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "PROP004",
+                    Severity = ValidationSeverity.Warning,
+                    Category = ValidationCategory.PropertyDefinition,
+                    Message = $"Unrecognized collection type: {prop.CollectionType}",
+                    Details = $"Property '{prop.Name}' uses collection type '{prop.CollectionType}'",
+                    SuggestedFix = "Use a standard collection type: List<T>, ICollection<T>, IEnumerable<T>, etc.",
+                    RelatedElement = prop.Name
+                });
+            }
+        }
+    }
+
+    private PlantUmlEntityValidationResult ValidateEnum(PlantUmlEnumModel enm)
+    {
+        var result = new PlantUmlEntityValidationResult
+        {
+            EntityName = enm.Name,
+            EntityType = "Enum",
+            Namespace = enm.Namespace
+        };
+
+        // Validate enum name
+        if (string.IsNullOrWhiteSpace(enm.Name))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "ENUM001",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.EntityDefinition,
+                Message = "Enum has no name",
+                SuggestedFix = "Provide a valid enum name"
+            });
+            return result;
+        }
+
+        // Validate enum name is PascalCase
+        if (!char.IsUpper(enm.Name[0]))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "ENUM002",
+                Severity = ValidationSeverity.Warning,
+                Category = ValidationCategory.Naming,
+                Message = "Enum name should start with uppercase letter (PascalCase)",
+                Details = $"Enum name '{enm.Name}' starts with lowercase",
+                SuggestedFix = $"Rename to '{char.ToUpper(enm.Name[0])}{enm.Name[1..]}'",
+                RelatedElement = enm.Name
+            });
+        }
+
+        // Validate enum has values
+        if (enm.Values == null || enm.Values.Count == 0)
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "ENUM003",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.EntityDefinition,
+                Message = "Enum has no values defined",
+                Details = $"Enum '{enm.Name}' is empty",
+                SuggestedFix = "Add at least one value to the enum",
+                RelatedElement = enm.Name
+            });
+        }
+        else
+        {
+            // Validate enum values are PascalCase
+            foreach (var value in enm.Values)
+            {
+                if (!string.IsNullOrEmpty(value) && !char.IsUpper(value[0]))
+                {
+                    result.Issues.Add(new PlantUmlValidationIssue
+                    {
+                        Code = "ENUM004",
+                        Severity = ValidationSeverity.Warning,
+                        Category = ValidationCategory.Naming,
+                        Message = "Enum value should start with uppercase letter (PascalCase)",
+                        Details = $"Enum value '{value}' in '{enm.Name}' starts with lowercase",
+                        SuggestedFix = $"Rename to '{char.ToUpper(value[0])}{value[1..]}'",
+                        RelatedElement = value
+                    });
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private void ValidateRelationships(PlantUmlDocumentModel document, PlantUmlDocumentValidationResult result)
+    {
+        // Get all known class and enum names in this document
+        var knownTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var cls in document.Classes)
+        {
+            knownTypes.Add(cls.Name);
+        }
+
+        foreach (var pkg in document.Packages)
+        {
+            foreach (var cls in pkg.Classes)
+            {
+                knownTypes.Add(cls.Name);
+            }
+
+            foreach (var enm in pkg.Enums)
+            {
+                knownTypes.Add(enm.Name);
+            }
+        }
+
+        foreach (var enm in document.Enums)
+        {
+            knownTypes.Add(enm.Name);
+        }
+
+        // Validate each relationship
+        foreach (var rel in document.Relationships)
+        {
+            // Validate source class exists
+            if (!knownTypes.Contains(rel.SourceClass) && !ValidPrimitiveTypes.Contains(rel.SourceClass))
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "REL001",
+                    Severity = ValidationSeverity.Warning,
+                    Category = ValidationCategory.Relationship,
+                    Message = $"Relationship references unknown source class: {rel.SourceClass}",
+                    Details = $"Class '{rel.SourceClass}' is not defined in this document",
+                    SuggestedFix = "Define the class or fix the relationship reference",
+                    RelatedElement = rel.SourceClass
+                });
+            }
+
+            // Validate target class exists
+            if (!knownTypes.Contains(rel.TargetClass) && !ValidPrimitiveTypes.Contains(rel.TargetClass))
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "REL002",
+                    Severity = ValidationSeverity.Warning,
+                    Category = ValidationCategory.Relationship,
+                    Message = $"Relationship references unknown target class: {rel.TargetClass}",
+                    Details = $"Class '{rel.TargetClass}' is not defined in this document",
+                    SuggestedFix = "Define the class or fix the relationship reference",
+                    RelatedElement = rel.TargetClass
+                });
+            }
+
+            // Validate cardinality for composition/aggregation
+            if ((rel.RelationshipType == PlantUmlRelationshipType.Composition ||
+                 rel.RelationshipType == PlantUmlRelationshipType.Aggregation) &&
+                string.IsNullOrEmpty(rel.SourceCardinality) && string.IsNullOrEmpty(rel.TargetCardinality))
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "REL003",
+                    Severity = ValidationSeverity.Info,
+                    Category = ValidationCategory.Relationship,
+                    Message = "Relationship is missing cardinality",
+                    Details = $"Relationship between '{rel.SourceClass}' and '{rel.TargetClass}' has no cardinality specified",
+                    SuggestedFix = "Add cardinality (e.g., \"1\" *-- \"0..*\" for one-to-many)",
+                    RelatedElement = $"{rel.SourceClass} -> {rel.TargetClass}"
+                });
+            }
+        }
+    }
+
+    private void ValidateComponents(PlantUmlDocumentModel document, PlantUmlDocumentValidationResult result)
+    {
+        var componentNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var componentAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var component in document.Components)
+        {
+            // Check for duplicate component names
+            if (!componentNames.Add(component.Name))
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "COMP001",
+                    Severity = ValidationSeverity.Error,
+                    Category = ValidationCategory.Duplicate,
+                    Message = $"Duplicate component name: {component.Name}",
+                    SuggestedFix = "Use unique component names",
+                    RelatedElement = component.Name
+                });
+            }
+
+            // Check for duplicate aliases
+            if (!string.IsNullOrEmpty(component.Alias) && !componentAliases.Add(component.Alias))
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "COMP002",
+                    Severity = ValidationSeverity.Error,
+                    Category = ValidationCategory.Duplicate,
+                    Message = $"Duplicate component alias: {component.Alias}",
+                    SuggestedFix = "Use unique component aliases",
+                    RelatedElement = component.Alias
+                });
+            }
+
+            // Validate controller components have endpoint specifications
+            if (component.Name.EndsWith("Controller", StringComparison.OrdinalIgnoreCase) &&
+                component.EndpointSpec == null)
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "COMP003",
+                    Severity = ValidationSeverity.Info,
+                    Category = ValidationCategory.BestPractice,
+                    Message = $"Controller component is missing endpoint specification",
+                    Details = $"Component '{component.Name}' appears to be a controller but has no endpoint note",
+                    SuggestedFix = "Add a note with endpoint specifications (Route, HTTP verbs, etc.)",
+                    RelatedElement = component.Name
+                });
+            }
+        }
+    }
+
+    private void ValidateCrossDocumentConsistency(PlantUmlSolutionModel model, PlantUmlValidationResult result)
+    {
+        var allClasses = model.GetAllClasses().ToList();
+        var allEnums = model.GetAllEnums().ToList();
+        var allTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Build set of all defined types
+        foreach (var cls in allClasses)
+        {
+            allTypes.Add(cls.Name);
+        }
+
+        foreach (var enm in allEnums)
+        {
+            allTypes.Add(enm.Name);
+        }
+
+        // Check for duplicate class definitions across documents
+        var classNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var doc in model.Documents)
+        {
+            foreach (var cls in doc.Classes.Concat(doc.Packages.SelectMany(p => p.Classes)))
+            {
+                if (classNames.TryGetValue(cls.Name, out var existingFile))
+                {
+                    if (!string.Equals(existingFile, doc.FilePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.GlobalIssues.Add(new PlantUmlValidationIssue
+                        {
+                            Code = "DUP001",
+                            Severity = ValidationSeverity.Error,
+                            Category = ValidationCategory.Duplicate,
+                            Message = $"Duplicate class definition: {cls.Name}",
+                            Details = $"Class '{cls.Name}' is defined in both '{Path.GetFileName(existingFile)}' and '{Path.GetFileName(doc.FilePath)}'",
+                            SuggestedFix = "Remove the duplicate definition or rename one of the classes",
+                            RelatedElement = cls.Name
+                        });
+                    }
+                }
+                else
+                {
+                    classNames[cls.Name] = doc.FilePath;
+                }
+            }
+        }
+
+        // Check for duplicate enum definitions
+        var enumNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var doc in model.Documents)
+        {
+            foreach (var enm in doc.Enums.Concat(doc.Packages.SelectMany(p => p.Enums)))
+            {
+                if (enumNames.TryGetValue(enm.Name, out var existingFile))
+                {
+                    if (!string.Equals(existingFile, doc.FilePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.GlobalIssues.Add(new PlantUmlValidationIssue
+                        {
+                            Code = "DUP002",
+                            Severity = ValidationSeverity.Error,
+                            Category = ValidationCategory.Duplicate,
+                            Message = $"Duplicate enum definition: {enm.Name}",
+                            Details = $"Enum '{enm.Name}' is defined in both '{Path.GetFileName(existingFile)}' and '{Path.GetFileName(doc.FilePath)}'",
+                            SuggestedFix = "Remove the duplicate definition or rename one of the enums",
+                            RelatedElement = enm.Name
+                        });
+                    }
+                }
+                else
+                {
+                    enumNames[enm.Name] = doc.FilePath;
+                }
+            }
+        }
+
+        // Validate type references across all classes
+        foreach (var cls in allClasses)
+        {
+            foreach (var prop in cls.Properties)
+            {
+                var typeToCheck = prop.IsCollection ? prop.GenericTypeArgument : prop.Type;
+
+                if (!string.IsNullOrEmpty(typeToCheck) &&
+                    !ValidPrimitiveTypes.Contains(typeToCheck) &&
+                    !allTypes.Contains(typeToCheck))
+                {
+                    result.GlobalIssues.Add(new PlantUmlValidationIssue
+                    {
+                        Code = "TYPE001",
+                        Severity = ValidationSeverity.Warning,
+                        Category = ValidationCategory.TypeReference,
+                        Message = $"Property references undefined type: {typeToCheck}",
+                        Details = $"Property '{prop.Name}' in class '{cls.Name}' references type '{typeToCheck}' which is not defined",
+                        SuggestedFix = $"Define the type '{typeToCheck}' or use a valid type",
+                        RelatedElement = $"{cls.Name}.{prop.Name}"
+                    });
+                }
+            }
+        }
+
+        // Validate bounded contexts consistency
+        var boundedContexts = model.GetBoundedContexts().ToList();
+        if (boundedContexts.Count > 0)
+        {
+            result.GlobalIssues.Add(new PlantUmlValidationIssue
+            {
+                Code = "BC001",
+                Severity = ValidationSeverity.Info,
+                Category = ValidationCategory.Consistency,
+                Message = $"Found {boundedContexts.Count} bounded context(s)",
+                Details = $"Bounded contexts: {string.Join(", ", boundedContexts)}",
+                SuggestedFix = "Ensure all entities are correctly assigned to their bounded contexts"
+            });
+        }
+
+        // Check for aggregates without relationships
+        var aggregates = model.GetAggregates().ToList();
+        var allRelationships = model.GetAllRelationships().ToList();
+
+        foreach (var agg in aggregates)
+        {
+            var hasChildren = allRelationships.Any(r =>
+                r.SourceClass.Equals(agg.Name, StringComparison.OrdinalIgnoreCase) &&
+                (r.RelationshipType == PlantUmlRelationshipType.Composition ||
+                 r.RelationshipType == PlantUmlRelationshipType.Aggregation));
+
+            var hasCollectionProperties = agg.Properties.Any(p => p.IsCollection);
+
+            if (!hasChildren && hasCollectionProperties)
+            {
+                result.GlobalIssues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "AGG001",
+                    Severity = ValidationSeverity.Info,
+                    Category = ValidationCategory.Relationship,
+                    Message = $"Aggregate has collection properties but no explicit relationships",
+                    Details = $"Aggregate '{agg.Name}' has collection properties. Consider adding explicit relationships for clarity.",
+                    SuggestedFix = "Add relationships like: Parent \"1\" *-- \"0..*\" Child : contains",
+                    RelatedElement = agg.Name
+                });
+            }
+        }
+
+        // Check if there are any aggregates defined
+        if (aggregates.Count == 0 && allClasses.Count > 0)
+        {
+            result.GlobalIssues.Add(new PlantUmlValidationIssue
+            {
+                Code = "AGG002",
+                Severity = ValidationSeverity.Warning,
+                Category = ValidationCategory.Stereotype,
+                Message = "No aggregate roots defined",
+                Details = $"Found {allClasses.Count} class(es) but none are marked with <<aggregate>> stereotype",
+                SuggestedFix = "Mark at least one entity as an aggregate root using the <<aggregate>> stereotype"
+            });
+        }
+    }
+
+    private async Task ValidateRawFileContentsAsync(string directoryPath, PlantUmlValidationResult result, CancellationToken cancellationToken)
+    {
+        var pumlFiles = fileSystem.Directory.GetFiles(directoryPath, "*.puml", SearchOption.AllDirectories);
+
+        foreach (var file in pumlFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var content = await Task.Run(() => fileSystem.File.ReadAllText(file), cancellationToken);
+                var docResult = result.DocumentResults.FirstOrDefault(d =>
+                    string.Equals(d.FilePath, file, StringComparison.OrdinalIgnoreCase));
+
+                if (docResult == null)
+                {
+                    docResult = new PlantUmlDocumentValidationResult { FilePath = file };
+                    result.DocumentResults.Add(docResult);
+                }
+
+                ValidateRawContent(content, file, docResult);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Error reading file for raw validation: {File}", file);
+            }
+        }
+    }
+
+    private void ValidateRawContent(string content, string filePath, PlantUmlDocumentValidationResult result)
+    {
+        var lines = content.Split('\n');
+
+        // Check for @startuml and @enduml
+        var hasStartUml = content.Contains("@startuml", StringComparison.OrdinalIgnoreCase);
+        var hasEndUml = content.Contains("@enduml", StringComparison.OrdinalIgnoreCase);
+
+        if (!hasStartUml)
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "STRUCT001",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.DocumentStructure,
+                Message = "Missing @startuml declaration",
+                Details = "Every PlantUML document must begin with @startuml",
+                SuggestedFix = "Add @startuml at the beginning of the file"
+            });
+        }
+
+        if (!hasEndUml)
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "STRUCT002",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.DocumentStructure,
+                Message = "Missing @enduml declaration",
+                Details = "Every PlantUML document must end with @enduml",
+                SuggestedFix = "Add @enduml at the end of the file"
+            });
+        }
+
+        // Check for unclosed blocks
+        ValidateBlockClosure(content, "class", "{", "}", result);
+        ValidateBlockClosure(content, "enum", "{", "}", result);
+        ValidateBlockClosure(content, "package", "{", "}", result);
+
+        // Check for unclosed note blocks
+        var noteStartCount = Regex.Matches(content, @"\bnote\b", RegexOptions.IgnoreCase).Count;
+        var noteEndCount = Regex.Matches(content, @"\bend note\b", RegexOptions.IgnoreCase).Count;
+
+        if (noteStartCount > noteEndCount)
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "STRUCT003",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.DocumentStructure,
+                Message = "Unclosed note block detected",
+                Details = $"Found {noteStartCount} note declarations but only {noteEndCount} 'end note' closures",
+                SuggestedFix = "Ensure all note blocks are closed with 'end note'"
+            });
+        }
+
+        // Check for multi-line component blocks (invalid in PlantUML)
+        var componentBlockPattern = @"component\s+""[^""]*""\s+as\s+\w+\s*\{[^}]+\}";
+        if (Regex.IsMatch(content, componentBlockPattern, RegexOptions.Singleline))
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "STRUCT004",
+                Severity = ValidationSeverity.Error,
+                Category = ValidationCategory.DocumentStructure,
+                Message = "Invalid multi-line component block detected",
+                Details = "Components cannot have multi-line content inside braces. Use notes instead.",
+                SuggestedFix = "Use 'component [Name] as alias' with a separate 'note right of alias' block"
+            });
+        }
+
+        // Check for valid title
+        var titleMatch = Regex.Match(content, @"title\s+(.+)", RegexOptions.Multiline);
+        if (!titleMatch.Success && hasStartUml)
+        {
+            result.Issues.Add(new PlantUmlValidationIssue
+            {
+                Code = "STRUCT005",
+                Severity = ValidationSeverity.Info,
+                Category = ValidationCategory.BestPractice,
+                Message = "Document is missing a title",
+                SuggestedFix = "Add a title: title Document Title - Version X.X"
+            });
+        }
+    }
+
+    private void ValidateBlockClosure(string content, string blockType, string openBrace, string closeBrace, PlantUmlDocumentValidationResult result)
+    {
+        var pattern = $@"\b{blockType}\b";
+        var blockStarts = Regex.Matches(content, pattern, RegexOptions.IgnoreCase).Count;
+
+        if (blockStarts > 0)
+        {
+            // Simple brace counting for the whole document
+            var openCount = content.Count(c => c == openBrace[0]);
+            var closeCount = content.Count(c => c == closeBrace[0]);
+
+            if (openCount != closeCount)
+            {
+                result.Issues.Add(new PlantUmlValidationIssue
+                {
+                    Code = "STRUCT006",
+                    Severity = ValidationSeverity.Error,
+                    Category = ValidationCategory.DocumentStructure,
+                    Message = $"Mismatched braces detected",
+                    Details = $"Found {openCount} opening braces and {closeCount} closing braces",
+                    SuggestedFix = "Ensure all blocks are properly closed with matching braces"
+                });
+            }
+        }
+    }
+}

--- a/src/Endpoint.DotNet/ConfigureServices.cs
+++ b/src/Endpoint.DotNet/ConfigureServices.cs
@@ -94,6 +94,7 @@ public static class ConfigureServices
         // PlantUML services
         services.AddSingleton<IPlantUmlParserService, PlantUmlParserService>();
         services.AddSingleton<IPlantUmlSolutionModelFactory, PlantUmlSolutionModelFactory>();
+        services.AddSingleton<IPlantUmlValidationService, PlantUmlValidationService>();
 
         services.AddSingleton<ITemplateLocator, EmbeddedResourceTemplateLocatorBase<CodeGeneratorApplication>>();
 


### PR DESCRIPTION
Add comprehensive validation for PlantUML files against the plantuml-scaffolding.spec:

- Create PlantUmlValidationResult model with detailed validation result structures including document-level, entity-level, and global issue tracking
- Implement IPlantUmlValidationService interface for validation operations
- Implement PlantUmlValidationService with comprehensive validation rules:
  - Document structure validation (@startuml/@enduml, unclosed blocks, notes)
  - Entity definition validation (primary keys, properties, stereotypes)
  - Property validation (types, naming conventions, nullability)
  - Enum validation (values, naming)
  - Relationship validation (cardinality, type references)
  - Cross-document consistency (duplicates, type references, bounded contexts)
  - Best practice recommendations (audit fields, aggregate roots)
- Update SolutionPlantumlValidateRequestHandler to use validation service and generate detailed markdown validation reports
- Register IPlantUmlValidationService in DI container

The validation ensures PlantUML files can generate valid solutions via SolutionCreateFromPlantUml command by detecting issues before generation.