### PR TITLE
Implement messaging-add command with Redis Pub/Sub support

### DIFF
--- a/docs/templates/command-artifact-generation-template.md
+++ b/docs/templates/command-artifact-generation-template.md
@@ -1,0 +1,255 @@
+# Command Artifact Generation Template
+
+This template provides guidelines for implementing CLI commands that generate a series of artifacts based on a specification and create a demo playground project.
+
+## Overview
+
+When implementing a new command that generates artifacts (like `messaging-add`, `signalr-add`, etc.), follow this structured approach to ensure consistency, testability, and documentation.
+
+## Implementation Steps
+
+### Step 1: Design the Models
+
+Create models in `src/Endpoint.Engineering/{FeatureName}/Models/`:
+
+1. **Main Model** - Represents the overall configuration (e.g., `MessagingModel`)
+   - Include all configuration options
+   - Use computed properties for derived values (e.g., `ProjectName`, `Namespace`)
+   - Default values should be sensible
+
+2. **Component Models** - Represent individual generated artifacts
+   - One model per major component (e.g., `MessageHeaderModel`, `MessageEnvelopeModel`)
+   - Include all properties needed for code generation
+
+```csharp
+// Example: src/Endpoint.Engineering/YourFeature/Models/YourFeatureModel.cs
+namespace Endpoint.Engineering.YourFeature.Models;
+
+public class YourFeatureModel
+{
+    public string SolutionName { get; set; } = string.Empty;
+    public string ProjectName => $"{SolutionName}.YourFeature";
+    public string Namespace => ProjectName;
+    public string Directory { get; set; } = string.Empty;
+    // Add feature-specific options
+}
+```
+
+### Step 2: Create the Artifact Factory
+
+Create artifacts in `src/Endpoint.Engineering/{FeatureName}/Artifacts/`:
+
+1. **IArtifactFactory** - Interface defining factory methods
+2. **ArtifactFactory** - Implementation that creates project models with files
+
+```csharp
+// Example: src/Endpoint.Engineering/YourFeature/Artifacts/IArtifactFactory.cs
+public interface IArtifactFactory
+{
+    Task<YourProjectModel> CreateProjectAsync(YourFeatureModel model, CancellationToken cancellationToken = default);
+}
+```
+
+The factory should:
+- Create the project model
+- Add all required NuGet packages
+- Create file models for each generated class/interface
+- Use string interpolation or templates for code generation
+
+### Step 3: Create Generation Strategies
+
+Create strategies in `src/Endpoint.Engineering/{FeatureName}/Artifacts/Strategies/`:
+
+```csharp
+// Example: YourProjectArtifactGenerationStrategy.cs
+public class YourProjectArtifactGenerationStrategy : IArtifactGenerationStrategy<YourProjectModel>
+{
+    // Inject IProjectService and IArtifactGenerator
+
+    public async Task GenerateAsync(YourProjectModel model, CancellationToken cancellationToken = default)
+    {
+        await _projectService.AddProjectAsync(model);
+        foreach (var file in model.Files)
+        {
+            await _artifactGenerator.GenerateAsync(file, cancellationToken);
+        }
+        _projectService.AddToSolution(model);
+    }
+}
+```
+
+### Step 4: Register Services
+
+Create `ConfigureServices.cs` in `src/Endpoint.Engineering/{FeatureName}/`:
+
+```csharp
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class YourFeatureConfigureServices
+{
+    public static IServiceCollection AddYourFeatureServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IArtifactFactory, ArtifactFactory>();
+        services.AddArifactGenerator(typeof(YourProjectModel).Assembly);
+        return services;
+    }
+}
+```
+
+Add to `Program.cs`:
+```csharp
+services.AddYourFeatureServices();
+```
+
+### Step 5: Implement the CLI Command
+
+Update the command in `src/Endpoint.Engineering.Cli/Commands/`:
+
+```csharp
+[Verb("your-feature-add")]
+public class YourFeatureAddRequest : IRequest
+{
+    [Option('n', "name", HelpText = "Solution name")]
+    public string? Name { get; set; }
+
+    [Option('d', "directory", Required = false)]
+    public string Directory { get; set; } = Environment.CurrentDirectory;
+
+    // Add feature-specific options with defaults
+}
+
+public class YourFeatureAddRequestHandler : IRequestHandler<YourFeatureAddRequest>
+{
+    // Inject required services
+
+    public async Task Handle(YourFeatureAddRequest request, CancellationToken cancellationToken)
+    {
+        // 1. Find the solution file using IFileProvider
+        // 2. Determine solution name and directory
+        // 3. Create the feature model
+        // 4. Use artifact factory to create project model
+        // 5. Use artifact generator to generate files
+    }
+}
+```
+
+### Step 6: Create Playground Demo
+
+Create a playground project in `playground/{FeatureName}Demo/`:
+
+**Project file (`{FeatureName}Demo.csproj`):**
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Endpoint\Endpoint.csproj" />
+    <ProjectReference Include="..\..\src\Endpoint.DotNet\Endpoint.DotNet.csproj" />
+    <ProjectReference Include="..\..\src\Endpoint.Engineering\Endpoint.Engineering.csproj" />
+    <ProjectReference Include="..\..\src\Endpoint.Engineering.Cli\Endpoint.Engineering.Cli.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.4.0" />
+    <!-- Other required packages -->
+  </ItemGroup>
+</Project>
+```
+
+**Program.cs:**
+```csharp
+// 1. Setup DI with all required services
+// 2. Create a demo solution
+// 3. Use MediatR to send the request
+// 4. Log results and generated files
+```
+
+### Step 7: Create Unit Tests
+
+Create tests following this structure:
+
+```
+tests/Endpoint.Engineering.UnitTests/{FeatureName}/
+├── Models/
+│   ├── YourFeatureModelTests.cs
+│   └── ComponentModelTests.cs
+├── Artifacts/
+│   ├── YourProjectModelTests.cs
+│   └── ArtifactFactoryTests.cs
+
+tests/Endpoint.Engineering.Cli.UnitTests/Commands/
+└── YourFeatureAddRequestHandlerTests.cs
+```
+
+**Test coverage requirements:**
+- All model properties and defaults
+- Factory methods and file generation
+- Command handler logic
+- Error handling
+- Null parameter validation
+
+**Minimum coverage target: 80%**
+
+## Checklist
+
+- [ ] **Models** created in `src/Endpoint.Engineering/{FeatureName}/Models/`
+- [ ] **Artifact Factory** created with interface and implementation
+- [ ] **Generation Strategies** created for artifact generation
+- [ ] **ConfigureServices** extension method added
+- [ ] **CLI Command** implemented with proper options
+- [ ] **Playground Demo** project created
+- [ ] **Unit Tests** with 80%+ coverage
+- [ ] **Documentation** updated if needed
+
+## File Structure
+
+```
+src/
+├── Endpoint.Engineering/
+│   └── {FeatureName}/
+│       ├── Models/
+│       │   ├── YourFeatureModel.cs
+│       │   └── ComponentModels.cs
+│       ├── Artifacts/
+│       │   ├── IArtifactFactory.cs
+│       │   ├── ArtifactFactory.cs
+│       │   ├── YourProjectModel.cs
+│       │   └── Strategies/
+│       │       └── YourProjectArtifactGenerationStrategy.cs
+│       └── ConfigureServices.cs
+├── Endpoint.Engineering.Cli/
+│   └── Commands/
+│       └── YourFeatureAdd.cs
+
+playground/
+└── {FeatureName}Demo/
+    ├── {FeatureName}Demo.csproj
+    └── Program.cs
+
+tests/
+├── Endpoint.Engineering.UnitTests/
+│   └── {FeatureName}/
+│       ├── Models/
+│       └── Artifacts/
+└── Endpoint.Engineering.Cli.UnitTests/
+    └── Commands/
+        └── YourFeatureAddRequestHandlerTests.cs
+```
+
+## Example Implementation Reference
+
+See the `messaging-add` command implementation:
+- Models: `src/Endpoint.Engineering/RedisPubSub/Models/`
+- Artifacts: `src/Endpoint.Engineering/RedisPubSub/Artifacts/`
+- Command: `src/Endpoint.Engineering.Cli/Commands/MessagingAdd.cs`
+- Playground: `playground/MessagingDemo/`
+
+## Tips
+
+1. **Use existing patterns** - Look at `ModernWebAppPattern` and `DomainDrivenDesign` for reference
+2. **Code generation** - Use raw strings with interpolation for simple files, syntax models for complex C# code
+3. **Package versions** - Use stable versions and document any alpha/beta packages
+4. **Logging** - Add informative logging at each major step
+5. **Validation** - Validate inputs early and provide clear error messages
+6. **Testability** - Use interfaces and dependency injection for all services

--- a/playground/MessagingDemo/MessagingDemo.csproj
+++ b/playground/MessagingDemo/MessagingDemo.csproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>1998,4014,SA1101,SA1600,SA1200,SA1633,1591,SA1309</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Core Endpoint references -->
+    <ProjectReference Include="..\..\src\Endpoint\Endpoint.csproj" />
+    <ProjectReference Include="..\..\src\Endpoint.DotNet\Endpoint.DotNet.csproj" />
+    <ProjectReference Include="..\..\src\Endpoint.Engineering\Endpoint.Engineering.csproj" />
+    <ProjectReference Include="..\..\src\Endpoint.Engineering.Cli\Endpoint.Engineering.Cli.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Required packages -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="12.4.0" />
+  </ItemGroup>
+</Project>

--- a/playground/MessagingDemo/Program.cs
+++ b/playground/MessagingDemo/Program.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint;
+using Endpoint.Artifacts.Abstractions;
+using Endpoint.Cli.Commands;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+// Setup dependency injection
+var services = new ServiceCollection();
+
+// Add logging
+services.AddLogging(builder =>
+{
+    builder.AddConsole();
+    builder.SetMinimumLevel(LogLevel.Information);
+});
+
+// Add MediatR and scan the assembly containing MessagingAddRequest
+services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<MessagingAddRequest>());
+
+// Add core services from Endpoint assembly
+services.AddCoreServices(typeof(IArtifactGenerator).Assembly);
+
+// Add DotNet services
+services.AddDotNetServices();
+
+// Add ModernWebAppPattern services
+services.AddModernWebAppPatternCoreServices();
+
+// Add RedisPubSub services
+services.AddRedisPubSubServices();
+
+var serviceProvider = services.BuildServiceProvider();
+
+var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
+var mediator = serviceProvider.GetRequiredService<IMediator>();
+
+try
+{
+    logger.LogInformation("=== Messaging Project Demo ===");
+    logger.LogInformation("This demo will create a messaging project with Redis Pub/Sub support.");
+    logger.LogInformation("");
+
+    // Get the output directory (parent of playground)
+    var playgroundDirectory = Path.Combine(Directory.GetCurrentDirectory(), "..");
+    var demoSolutionDirectory = Path.Combine(playgroundDirectory, "MessagingDemoSolution");
+
+    // Clean up any existing demo directory
+    if (Directory.Exists(demoSolutionDirectory))
+    {
+        logger.LogInformation("Cleaning up existing demo directory...");
+        Directory.Delete(demoSolutionDirectory, recursive: true);
+    }
+
+    // Create the demo solution directory
+    Directory.CreateDirectory(demoSolutionDirectory);
+
+    // Create a basic solution file for the demo
+    var solutionName = "MessagingDemoSolution";
+    var solutionPath = Path.Combine(demoSolutionDirectory, $"{solutionName}.sln");
+
+    logger.LogInformation("Creating demo solution: {SolutionName}", solutionName);
+
+    // Create a minimal solution file
+    var solutionContent = $"""
+        Microsoft Visual Studio Solution File, Format Version 12.00
+        # Visual Studio Version 17
+        VisualStudioVersion = 17.0.31903.59
+        MinimumVisualStudioVersion = 10.0.40219.1
+        Global
+        	GlobalSection(SolutionProperties) = preSolution
+        		HideSolutionNode = FALSE
+        	EndGlobalSection
+        EndGlobal
+        """;
+
+    await File.WriteAllTextAsync(solutionPath, solutionContent);
+
+    logger.LogInformation("Solution created at: {SolutionPath}", solutionPath);
+    logger.LogInformation("");
+
+    // Create request to add messaging project
+    var request = new MessagingAddRequest
+    {
+        Name = solutionName,
+        Directory = demoSolutionDirectory,
+        UseLz4Compression = true
+    };
+
+    logger.LogInformation("Adding messaging project to solution...");
+    logger.LogInformation("- Solution: {SolutionName}", solutionName);
+    logger.LogInformation("- Project: {ProjectName}", $"{solutionName}.Messaging");
+    logger.LogInformation("- LZ4 Compression: {UseLz4}", request.UseLz4Compression);
+    logger.LogInformation("");
+
+    await mediator.Send(request);
+
+    logger.LogInformation("");
+    logger.LogInformation("=== Demo Completed Successfully! ===");
+    logger.LogInformation("");
+    logger.LogInformation("Generated files:");
+
+    // List the generated files
+    var messagingProjectDir = Path.Combine(demoSolutionDirectory, $"{solutionName}.Messaging");
+    if (Directory.Exists(messagingProjectDir))
+    {
+        foreach (var file in Directory.GetFiles(messagingProjectDir, "*.*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(demoSolutionDirectory, file);
+            logger.LogInformation("  - {FilePath}", relativePath);
+        }
+    }
+
+    logger.LogInformation("");
+    logger.LogInformation("The messaging project includes:");
+    logger.LogInformation("  - IMessage, IDomainEvent, ICommand interfaces");
+    logger.LogInformation("  - MessageHeader and MessageEnvelope classes with MessagePack serialization");
+    logger.LogInformation("  - IMessageSerializer interface and MessagePackMessageSerializer implementation");
+    logger.LogInformation("  - IMessageTypeRegistry interface and MessageTypeRegistry implementation");
+    logger.LogInformation("  - ConfigureServices extension for dependency injection");
+}
+catch (Exception ex)
+{
+    logger.LogError(ex, "Error during messaging demo");
+}

--- a/src/Endpoint.Engineering.Cli/Commands/MessagingAdd.cs
+++ b/src/Endpoint.Engineering.Cli/Commands/MessagingAdd.cs
@@ -1,38 +1,123 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.IO.Abstractions;
 using CommandLine;
+using Endpoint.Artifacts.Abstractions;
+using Endpoint.Engineering.RedisPubSub.Artifacts;
+using Endpoint.Engineering.RedisPubSub.Models;
+using Endpoint.Services;
 using MediatR;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-
 
 namespace Endpoint.Engineering.Cli.Commands;
 
-
+/// <summary>
+/// Request to add a messaging project to a solution.
+/// </summary>
 [Verb("messaging-add")]
-public class MessagingAddRequest : IRequest {
-    [Option('n',"name")]
-    public string Name { get; set; }
+public class MessagingAddRequest : IRequest
+{
+    /// <summary>
+    /// Gets or sets the name of the solution. If not provided, it will be determined from the .sln file.
+    /// </summary>
+    [Option('n', "name", HelpText = "The name of the solution. If not provided, it will be determined from the .sln file.")]
+    public string? Name { get; set; }
 
+    /// <summary>
+    /// Gets or sets the directory to search for the solution file.
+    /// </summary>
+    [Option('d', "directory", Required = false, HelpText = "The directory to search for the solution file.")]
+    public string Directory { get; set; } = Environment.CurrentDirectory;
 
-    [Option('d', Required = false)]
-    public string Directory { get; set; } = System.Environment.CurrentDirectory;
+    /// <summary>
+    /// Gets or sets whether to use LZ4 compression with MessagePack.
+    /// </summary>
+    [Option("lz4", Required = false, Default = true, HelpText = "Whether to use LZ4 compression with MessagePack.")]
+    public bool UseLz4Compression { get; set; } = true;
 }
 
+/// <summary>
+/// Handler for adding a messaging project to a solution.
+/// </summary>
 public class MessagingAddRequestHandler : IRequestHandler<MessagingAddRequest>
 {
     private readonly ILogger<MessagingAddRequestHandler> _logger;
+    private readonly IFileProvider _fileProvider;
+    private readonly IFileSystem _fileSystem;
+    private readonly IArtifactFactory _artifactFactory;
+    private readonly IArtifactGenerator _artifactGenerator;
 
-    public MessagingAddRequestHandler(ILogger<MessagingAddRequestHandler> logger)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagingAddRequestHandler"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="fileProvider">The file provider.</param>
+    /// <param name="fileSystem">The file system abstraction.</param>
+    /// <param name="artifactFactory">The artifact factory.</param>
+    /// <param name="artifactGenerator">The artifact generator.</param>
+    public MessagingAddRequestHandler(
+        ILogger<MessagingAddRequestHandler> logger,
+        IFileProvider fileProvider,
+        IFileSystem fileSystem,
+        IArtifactFactory artifactFactory,
+        IArtifactGenerator artifactGenerator)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(fileProvider);
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentNullException.ThrowIfNull(artifactFactory);
+        ArgumentNullException.ThrowIfNull(artifactGenerator);
+
+        _logger = logger;
+        _fileProvider = fileProvider;
+        _fileSystem = fileSystem;
+        _artifactFactory = artifactFactory;
+        _artifactGenerator = artifactGenerator;
     }
 
+    /// <inheritdoc/>
     public async Task Handle(MessagingAddRequest request, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Handled: {0}", nameof(MessagingAddRequestHandler));
+        _logger.LogInformation("Adding messaging project to solution...");
+
+        // Find the solution file
+        var solutionPath = _fileProvider.Get("*.sln", request.Directory);
+
+        if (solutionPath == Endpoint.Constants.FileNotFound)
+        {
+            _logger.LogError("No solution file found in directory: {Directory}", request.Directory);
+            throw new InvalidOperationException($"No solution file found in directory: {request.Directory}");
+        }
+
+        // Determine the solution name
+        var solutionName = request.Name ?? _fileSystem.Path.GetFileNameWithoutExtension(solutionPath);
+        var solutionDirectory = _fileSystem.Path.GetDirectoryName(solutionPath)!;
+
+        // Determine the src directory (prefer src subdirectory if it exists)
+        var srcDirectory = _fileSystem.Path.Combine(solutionDirectory, "src");
+        if (!_fileSystem.Directory.Exists(srcDirectory))
+        {
+            srcDirectory = solutionDirectory;
+        }
+
+        _logger.LogInformation("Found solution: {SolutionName} at {SolutionPath}", solutionName, solutionPath);
+        _logger.LogInformation("Creating messaging project in: {SrcDirectory}", srcDirectory);
+
+        // Create the messaging model
+        var messagingModel = new MessagingModel
+        {
+            SolutionName = solutionName,
+            Directory = srcDirectory,
+            UseLz4Compression = request.UseLz4Compression
+        };
+
+        // Create the messaging project model
+        var projectModel = await _artifactFactory.CreateMessagingProjectAsync(messagingModel, cancellationToken);
+
+        // Generate the messaging project
+        await _artifactGenerator.GenerateAsync(projectModel, cancellationToken);
+
+        _logger.LogInformation("Messaging project '{ProjectName}' added successfully!", projectModel.Name);
     }
 }

--- a/src/Endpoint.Engineering.Cli/Program.cs
+++ b/src/Endpoint.Engineering.Cli/Program.cs
@@ -34,6 +34,7 @@ var app = CodeGeneratorApplication.CreateBuilder()
         services.AddSingleton<ITemplateLocator, EmbeddedResourceTemplateLocatorBase<CodeGeneratorApplication>>();
         services.AddModernWebAppPatternCoreServices();
         services.AddAngularServices();
+        services.AddRedisPubSubServices();
     })
     .Build();
 

--- a/src/Endpoint.Engineering/RedisPubSub/Artifacts/ArtifactFactory.cs
+++ b/src/Endpoint.Engineering/RedisPubSub/Artifacts/ArtifactFactory.cs
@@ -1,0 +1,521 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO.Abstractions;
+using Endpoint.DotNet.Artifacts.Files;
+using Endpoint.Engineering.RedisPubSub.Models;
+using Microsoft.Extensions.Logging;
+using static Endpoint.DotNet.Constants.FileExtensions;
+
+namespace Endpoint.Engineering.RedisPubSub.Artifacts;
+
+/// <summary>
+/// Factory for creating messaging artifacts.
+/// </summary>
+public class ArtifactFactory : IArtifactFactory
+{
+    private readonly ILogger<ArtifactFactory> _logger;
+    private readonly IFileSystem _fileSystem;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArtifactFactory"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="fileSystem">The file system abstraction.</param>
+    public ArtifactFactory(ILogger<ArtifactFactory> logger, IFileSystem fileSystem)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(fileSystem);
+
+        _logger = logger;
+        _fileSystem = fileSystem;
+    }
+
+    /// <inheritdoc/>
+    public async Task<MessagingProjectModel> CreateMessagingProjectAsync(MessagingModel model, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Creating messaging project for solution: {SolutionName}", model.SolutionName);
+
+        var projectModel = new MessagingProjectModel(model.SolutionName, model.Directory)
+        {
+            UseLz4Compression = model.UseLz4Compression
+        };
+
+        var messagesDirectory = _fileSystem.Path.Combine(projectModel.Directory, "Messages");
+        var servicesDirectory = _fileSystem.Path.Combine(projectModel.Directory, "Services");
+
+        // Add IMessage interface
+        projectModel.Files.Add(CreateIMessageFile(projectModel.Namespace, messagesDirectory));
+
+        // Add IDomainEvent interface
+        projectModel.Files.Add(CreateIDomainEventFile(projectModel.Namespace, messagesDirectory));
+
+        // Add ICommand interface
+        projectModel.Files.Add(CreateICommandFile(projectModel.Namespace, messagesDirectory));
+
+        // Add MessageHeader class
+        projectModel.Files.Add(CreateMessageHeaderFile(projectModel.Namespace, messagesDirectory));
+
+        // Add MessageEnvelope class
+        projectModel.Files.Add(CreateMessageEnvelopeFile(projectModel.Namespace, messagesDirectory));
+
+        // Add IMessageSerializer interface
+        projectModel.Files.Add(CreateIMessageSerializerFile(projectModel.Namespace, servicesDirectory));
+
+        // Add MessagePackMessageSerializer class
+        projectModel.Files.Add(CreateMessagePackMessageSerializerFile(projectModel.Namespace, servicesDirectory, model.UseLz4Compression));
+
+        // Add IMessageTypeRegistry interface
+        projectModel.Files.Add(CreateIMessageTypeRegistryFile(projectModel.Namespace, servicesDirectory));
+
+        // Add MessageTypeRegistry class
+        projectModel.Files.Add(CreateMessageTypeRegistryFile(projectModel.Namespace, servicesDirectory));
+
+        // Add ConfigureServices extension
+        projectModel.Files.Add(CreateConfigureServicesFile(projectModel.Namespace, projectModel.Directory));
+
+        return projectModel;
+    }
+
+    private static FileModel CreateIMessageFile(string @namespace, string directory)
+    {
+        return new FileModel("IMessage", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Marker interface for all messages.
+            /// </summary>
+            public interface IMessage
+            {
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateIDomainEventFile(string @namespace, string directory)
+    {
+        return new FileModel("IDomainEvent", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Domain event marker interface.
+            /// </summary>
+            public interface IDomainEvent : IMessage
+            {
+                /// <summary>
+                /// Gets the aggregate ID.
+                /// </summary>
+                string AggregateId { get; }
+
+                /// <summary>
+                /// Gets the aggregate type.
+                /// </summary>
+                string AggregateType { get; }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateICommandFile(string @namespace, string directory)
+    {
+        return new FileModel("ICommand", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Command marker interface.
+            /// </summary>
+            public interface ICommand : IMessage
+            {
+                /// <summary>
+                /// Gets the target ID.
+                /// </summary>
+                string TargetId { get; }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateMessageHeaderFile(string @namespace, string directory)
+    {
+        return new FileModel("MessageHeader", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using MessagePack;
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Message header containing metadata for all messages.
+            /// </summary>
+            [MessagePackObject]
+            public sealed class MessageHeader
+            {
+                /// <summary>
+                /// Gets or sets the message type discriminator for deserialization.
+                /// </summary>
+                [Key(0)]
+                public required string MessageType { get; init; }
+
+                /// <summary>
+                /// Gets or sets the message ID for idempotency.
+                /// </summary>
+                [Key(1)]
+                public required string MessageId { get; init; }
+
+                /// <summary>
+                /// Gets or sets the correlation ID for distributed tracing.
+                /// </summary>
+                [Key(2)]
+                public required string CorrelationId { get; init; }
+
+                /// <summary>
+                /// Gets or sets the causation ID for event chain tracking.
+                /// </summary>
+                [Key(3)]
+                public required string CausationId { get; init; }
+
+                /// <summary>
+                /// Gets or sets the timestamp in Unix milliseconds.
+                /// </summary>
+                [Key(4)]
+                public required long TimestampUnixMs { get; init; }
+
+                /// <summary>
+                /// Gets or sets the source service name.
+                /// </summary>
+                [Key(5)]
+                public required string SourceService { get; init; }
+
+                /// <summary>
+                /// Gets or sets the schema version for evolution.
+                /// </summary>
+                [Key(6)]
+                public int SchemaVersion { get; init; } = 1;
+
+                /// <summary>
+                /// Gets or sets the metadata dictionary for extensibility.
+                /// </summary>
+                [Key(7)]
+                public Dictionary<string, string>? Metadata { get; init; }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateMessageEnvelopeFile(string @namespace, string directory)
+    {
+        return new FileModel("MessageEnvelope", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using MessagePack;
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Message envelope that wraps messages with header metadata.
+            /// </summary>
+            /// <typeparam name="TPayload">The type of the message payload.</typeparam>
+            [MessagePackObject]
+            public sealed class MessageEnvelope<TPayload> where TPayload : IMessage
+            {
+                /// <summary>
+                /// Gets or sets the message header.
+                /// </summary>
+                [Key(0)]
+                public MessageHeader Header { get; init; } = new()
+                {
+                    MessageType = string.Empty,
+                    MessageId = string.Empty,
+                    CorrelationId = string.Empty,
+                    CausationId = string.Empty,
+                    TimestampUnixMs = 0,
+                    SourceService = string.Empty
+                };
+
+                /// <summary>
+                /// Gets or sets the message payload.
+                /// </summary>
+                [Key(1)]
+                public TPayload Payload { get; init; } = default!;
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateIMessageSerializerFile(string @namespace, string directory)
+    {
+        return new FileModel("IMessageSerializer", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using {{@namespace}}.Messages;
+
+            namespace {{@namespace}}.Services;
+
+            /// <summary>
+            /// Interface for message serialization.
+            /// </summary>
+            public interface IMessageSerializer
+            {
+                /// <summary>
+                /// Serializes a message envelope to bytes.
+                /// </summary>
+                /// <typeparam name="T">The type of the message payload.</typeparam>
+                /// <param name="envelope">The message envelope to serialize.</param>
+                /// <returns>The serialized bytes.</returns>
+                byte[] Serialize<T>(MessageEnvelope<T> envelope) where T : IMessage;
+
+                /// <summary>
+                /// Deserializes bytes to a message envelope.
+                /// </summary>
+                /// <typeparam name="T">The type of the message payload.</typeparam>
+                /// <param name="data">The bytes to deserialize.</param>
+                /// <returns>The deserialized message envelope, or null if deserialization fails.</returns>
+                MessageEnvelope<T>? Deserialize<T>(ReadOnlyMemory<byte> data) where T : IMessage;
+
+                /// <summary>
+                /// Peeks at the header of a message without fully deserializing the payload.
+                /// </summary>
+                /// <param name="data">The bytes to peek.</param>
+                /// <returns>A tuple containing the header and payload type, or null if peek fails.</returns>
+                (MessageHeader Header, Type? PayloadType)? PeekHeader(ReadOnlyMemory<byte> data);
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateMessagePackMessageSerializerFile(string @namespace, string directory, bool useLz4Compression)
+    {
+        var compressionOption = useLz4Compression
+            ? ".WithCompression(MessagePackCompression.Lz4BlockArray)"
+            : string.Empty;
+
+        return new FileModel("MessagePackMessageSerializer", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using MessagePack;
+            using MessagePack.Resolvers;
+            using {{@namespace}}.Messages;
+
+            namespace {{@namespace}}.Services;
+
+            /// <summary>
+            /// MessagePack-based message serializer implementation.
+            /// </summary>
+            public sealed class MessagePackMessageSerializer : IMessageSerializer
+            {
+                private readonly IMessageTypeRegistry _registry;
+                private static readonly MessagePackSerializerOptions Options = MessagePackSerializerOptions.Standard
+                    .WithResolver(CompositeResolver.Create(
+                        StandardResolver.Instance)){{compressionOption}}
+                    .WithSecurity(MessagePackSecurity.UntrustedData);
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="MessagePackMessageSerializer"/> class.
+                /// </summary>
+                /// <param name="registry">The message type registry.</param>
+                public MessagePackMessageSerializer(IMessageTypeRegistry registry)
+                {
+                    _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+                }
+
+                /// <inheritdoc/>
+                public byte[] Serialize<T>(MessageEnvelope<T> envelope) where T : IMessage
+                {
+                    return MessagePackSerializer.Serialize(envelope, Options);
+                }
+
+                /// <inheritdoc/>
+                public MessageEnvelope<T>? Deserialize<T>(ReadOnlyMemory<byte> data) where T : IMessage
+                {
+                    return MessagePackSerializer.Deserialize<MessageEnvelope<T>>(data, Options);
+                }
+
+                /// <inheritdoc/>
+                public (MessageHeader Header, Type? PayloadType)? PeekHeader(ReadOnlyMemory<byte> data)
+                {
+                    try
+                    {
+                        var reader = new MessagePackReader(data);
+
+                        var mapCount = reader.ReadMapHeader();
+                        for (int i = 0; i < mapCount; i++)
+                        {
+                            var key = reader.ReadString();
+                            if (key == "Header")
+                            {
+                                var header = MessagePackSerializer.Deserialize<MessageHeader>(ref reader, Options);
+                                var payloadType = _registry.GetType(header.MessageType);
+                                return (header, payloadType);
+                            }
+                            reader.Skip();
+                        }
+                        return null;
+                    }
+                    catch
+                    {
+                        return null;
+                    }
+                }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateIMessageTypeRegistryFile(string @namespace, string directory)
+    {
+        return new FileModel("IMessageTypeRegistry", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using {{@namespace}}.Messages;
+
+            namespace {{@namespace}}.Services;
+
+            /// <summary>
+            /// Interface for message type registration and lookup.
+            /// </summary>
+            public interface IMessageTypeRegistry
+            {
+                /// <summary>
+                /// Registers a message type with a message type string.
+                /// </summary>
+                /// <typeparam name="T">The message type.</typeparam>
+                /// <param name="messageType">The message type string.</param>
+                void Register<T>(string messageType) where T : IMessage;
+
+                /// <summary>
+                /// Gets the CLR type for a message type string.
+                /// </summary>
+                /// <param name="messageType">The message type string.</param>
+                /// <returns>The CLR type, or null if not found.</returns>
+                Type? GetType(string messageType);
+
+                /// <summary>
+                /// Gets the message type string for a CLR type.
+                /// </summary>
+                /// <typeparam name="T">The message type.</typeparam>
+                /// <returns>The message type string, or null if not found.</returns>
+                string? GetMessageType<T>() where T : IMessage;
+
+                /// <summary>
+                /// Gets the message type string for a CLR type.
+                /// </summary>
+                /// <param name="type">The CLR type.</param>
+                /// <returns>The message type string, or null if not found.</returns>
+                string? GetMessageType(Type type);
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateMessageTypeRegistryFile(string @namespace, string directory)
+    {
+        return new FileModel("MessageTypeRegistry", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using {{@namespace}}.Messages;
+
+            namespace {{@namespace}}.Services;
+
+            /// <summary>
+            /// Implementation of message type registration and lookup.
+            /// </summary>
+            public sealed class MessageTypeRegistry : IMessageTypeRegistry
+            {
+                private readonly Dictionary<string, Type> _typeByName = new();
+                private readonly Dictionary<Type, string> _nameByType = new();
+
+                /// <inheritdoc/>
+                public void Register<T>(string messageType) where T : IMessage
+                {
+                    _typeByName[messageType] = typeof(T);
+                    _nameByType[typeof(T)] = messageType;
+                }
+
+                /// <inheritdoc/>
+                public Type? GetType(string messageType)
+                {
+                    return _typeByName.GetValueOrDefault(messageType);
+                }
+
+                /// <inheritdoc/>
+                public string? GetMessageType<T>() where T : IMessage
+                {
+                    return _nameByType.GetValueOrDefault(typeof(T));
+                }
+
+                /// <inheritdoc/>
+                public string? GetMessageType(Type type)
+                {
+                    return _nameByType.GetValueOrDefault(type);
+                }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateConfigureServicesFile(string @namespace, string directory)
+    {
+        return new FileModel("ConfigureServices", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using {{@namespace}}.Services;
+
+            namespace Microsoft.Extensions.DependencyInjection;
+
+            /// <summary>
+            /// Extension methods for configuring messaging services.
+            /// </summary>
+            public static class ConfigureServices
+            {
+                /// <summary>
+                /// Adds messaging services to the service collection.
+                /// </summary>
+                /// <param name="services">The service collection.</param>
+                /// <returns>The service collection for chaining.</returns>
+                public static IServiceCollection AddMessagingServices(this IServiceCollection services)
+                {
+                    services.AddSingleton<IMessageTypeRegistry, MessageTypeRegistry>();
+                    services.AddSingleton<IMessageSerializer, MessagePackMessageSerializer>();
+                    return services;
+                }
+            }
+            """
+        };
+    }
+}

--- a/src/Endpoint.Engineering/RedisPubSub/Artifacts/IArtifactFactory.cs
+++ b/src/Endpoint.Engineering/RedisPubSub/Artifacts/IArtifactFactory.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.RedisPubSub.Models;
+
+namespace Endpoint.Engineering.RedisPubSub.Artifacts;
+
+/// <summary>
+/// Factory interface for creating messaging artifacts.
+/// </summary>
+public interface IArtifactFactory
+{
+    /// <summary>
+    /// Creates a messaging project model.
+    /// </summary>
+    /// <param name="model">The messaging model.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation and contains the messaging project model.</returns>
+    Task<MessagingProjectModel> CreateMessagingProjectAsync(MessagingModel model, CancellationToken cancellationToken = default);
+}

--- a/src/Endpoint.Engineering/RedisPubSub/Artifacts/MessagingProjectModel.cs
+++ b/src/Endpoint.Engineering/RedisPubSub/Artifacts/MessagingProjectModel.cs
@@ -1,8 +1,44 @@
 // Copyright (c) Quinntyne Brown. All Rights Reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
+using Endpoint.DotNet.Artifacts.Projects;
+using Endpoint.DotNet.Artifacts.Projects.Enums;
 
 namespace Endpoint.Engineering.RedisPubSub.Artifacts;
 
-public class MessagingProjectModel : DotNet.Artifacts.Projects.ProjectModel { }
+/// <summary>
+/// Represents a messaging project model that includes MessagePack serialization support.
+/// </summary>
+public class MessagingProjectModel : ProjectModel
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagingProjectModel"/> class.
+    /// </summary>
+    public MessagingProjectModel()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagingProjectModel"/> class.
+    /// </summary>
+    /// <param name="solutionName">The name of the solution.</param>
+    /// <param name="parentDirectory">The parent directory for the project.</param>
+    public MessagingProjectModel(string solutionName, string parentDirectory)
+        : base(DotNetProjectType.ClassLib, $"{solutionName}.Messaging", parentDirectory)
+    {
+        SolutionName = solutionName;
+
+        // Add MessagePack package
+        Packages.Add(new PackageModel("MessagePack", "2.6.100-alpha"));
+    }
+
+    /// <summary>
+    /// Gets or sets the solution name.
+    /// </summary>
+    public string SolutionName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether to use LZ4 compression with MessagePack.
+    /// </summary>
+    public bool UseLz4Compression { get; set; } = true;
+}

--- a/src/Endpoint.Engineering/RedisPubSub/Artifacts/Strategies/MessagingProjectArtifactGenerationStrategy.cs
+++ b/src/Endpoint.Engineering/RedisPubSub/Artifacts/Strategies/MessagingProjectArtifactGenerationStrategy.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Artifacts;
+using Endpoint.Artifacts.Abstractions;
+using Endpoint.DotNet.Artifacts.Projects.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.RedisPubSub.Artifacts.Strategies;
+
+/// <summary>
+/// Generation strategy for messaging projects.
+/// </summary>
+public class MessagingProjectArtifactGenerationStrategy : IArtifactGenerationStrategy<MessagingProjectModel>
+{
+    private readonly ILogger<MessagingProjectArtifactGenerationStrategy> _logger;
+    private readonly IProjectService _projectService;
+    private readonly IArtifactGenerator _artifactGenerator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagingProjectArtifactGenerationStrategy"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="projectService">The project service.</param>
+    /// <param name="artifactGenerator">The artifact generator.</param>
+    public MessagingProjectArtifactGenerationStrategy(
+        ILogger<MessagingProjectArtifactGenerationStrategy> logger,
+        IProjectService projectService,
+        IArtifactGenerator artifactGenerator)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(projectService);
+        ArgumentNullException.ThrowIfNull(artifactGenerator);
+
+        _logger = logger;
+        _projectService = projectService;
+        _artifactGenerator = artifactGenerator;
+    }
+
+    /// <inheritdoc/>
+    public int GetPriority() => 1;
+
+    /// <inheritdoc/>
+    public async Task GenerateAsync(MessagingProjectModel model, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Generating messaging project: {ProjectName}", model.Name);
+
+        // Create the project using the project service
+        await _projectService.AddProjectAsync(model);
+
+        // Generate all files for the project
+        foreach (var file in model.Files)
+        {
+            await _artifactGenerator.GenerateAsync(file, cancellationToken);
+        }
+
+        // Add project to solution
+        _projectService.AddToSolution(model);
+
+        _logger.LogInformation("Messaging project generated successfully: {ProjectName}", model.Name);
+    }
+}

--- a/src/Endpoint.Engineering/RedisPubSub/ConfigureServices.cs
+++ b/src/Endpoint.Engineering/RedisPubSub/ConfigureServices.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint;
+using Endpoint.Engineering.RedisPubSub.Artifacts;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for configuring RedisPubSub services.
+/// </summary>
+public static class RedisPubSubConfigureServices
+{
+    /// <summary>
+    /// Adds RedisPubSub messaging services to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddRedisPubSubServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IArtifactFactory, ArtifactFactory>();
+        services.AddArifactGenerator(typeof(MessagingProjectModel).Assembly);
+
+        return services;
+    }
+}

--- a/src/Endpoint.Engineering/RedisPubSub/Models/MessageEnvelopeModel.cs
+++ b/src/Endpoint.Engineering/RedisPubSub/Models/MessageEnvelopeModel.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Endpoint.Engineering.RedisPubSub.Models;
+
+/// <summary>
+/// Represents the message envelope model for Redis Pub/Sub messaging.
+/// </summary>
+public class MessageEnvelopeModel
+{
+    /// <summary>
+    /// Gets or sets the name of the envelope class.
+    /// </summary>
+    public string Name { get; set; } = "MessageEnvelope";
+
+    /// <summary>
+    /// Gets or sets the namespace for the envelope.
+    /// </summary>
+    public string Namespace { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether to include generic payload type.
+    /// </summary>
+    public bool GenericPayload { get; set; } = true;
+}

--- a/src/Endpoint.Engineering/RedisPubSub/Models/MessageHeaderModel.cs
+++ b/src/Endpoint.Engineering/RedisPubSub/Models/MessageHeaderModel.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Endpoint.Engineering.RedisPubSub.Models;
+
+/// <summary>
+/// Represents the message header model for Redis Pub/Sub messaging.
+/// </summary>
+public class MessageHeaderModel
+{
+    /// <summary>
+    /// Gets or sets the message type discriminator for deserialization.
+    /// </summary>
+    public string MessageType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the message ID for idempotency.
+    /// </summary>
+    public string MessageId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the correlation ID for distributed tracing.
+    /// </summary>
+    public string CorrelationId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the causation ID for event chain tracking.
+    /// </summary>
+    public string CausationId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the timestamp in Unix milliseconds.
+    /// </summary>
+    public long TimestampUnixMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source service name.
+    /// </summary>
+    public string SourceService { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the schema version for evolution.
+    /// </summary>
+    public int SchemaVersion { get; set; } = 1;
+}

--- a/src/Endpoint.Engineering/RedisPubSub/Models/MessageSerializerModel.cs
+++ b/src/Endpoint.Engineering/RedisPubSub/Models/MessageSerializerModel.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Endpoint.Engineering.RedisPubSub.Models;
+
+/// <summary>
+/// Represents the message serializer model for Redis Pub/Sub messaging.
+/// </summary>
+public class MessageSerializerModel
+{
+    /// <summary>
+    /// Gets or sets the name of the serializer class.
+    /// </summary>
+    public string Name { get; set; } = "MessagePackMessageSerializer";
+
+    /// <summary>
+    /// Gets or sets the namespace for the serializer.
+    /// </summary>
+    public string Namespace { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether to use LZ4 compression.
+    /// </summary>
+    public bool UseLz4Compression { get; set; } = true;
+}

--- a/src/Endpoint.Engineering/RedisPubSub/Models/MessageTypeRegistryModel.cs
+++ b/src/Endpoint.Engineering/RedisPubSub/Models/MessageTypeRegistryModel.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Endpoint.Engineering.RedisPubSub.Models;
+
+/// <summary>
+/// Represents the message type registry model for Redis Pub/Sub messaging.
+/// </summary>
+public class MessageTypeRegistryModel
+{
+    /// <summary>
+    /// Gets or sets the name of the registry class.
+    /// </summary>
+    public string Name { get; set; } = "MessageTypeRegistry";
+
+    /// <summary>
+    /// Gets or sets the namespace for the registry.
+    /// </summary>
+    public string Namespace { get; set; } = string.Empty;
+}

--- a/src/Endpoint.Engineering/RedisPubSub/Models/MessagingModel.cs
+++ b/src/Endpoint.Engineering/RedisPubSub/Models/MessagingModel.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Endpoint.Engineering.RedisPubSub.Models;
+
+/// <summary>
+/// Represents the complete messaging model for generating a messaging project.
+/// </summary>
+public class MessagingModel
+{
+    /// <summary>
+    /// Gets or sets the solution name.
+    /// </summary>
+    public string SolutionName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the project name (defaults to {SolutionName}.Messaging).
+    /// </summary>
+    public string ProjectName => $"{SolutionName}.Messaging";
+
+    /// <summary>
+    /// Gets or sets the namespace for the messaging project.
+    /// </summary>
+    public string Namespace => ProjectName;
+
+    /// <summary>
+    /// Gets or sets the directory where the project will be created.
+    /// </summary>
+    public string Directory { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether to use LZ4 compression with MessagePack.
+    /// </summary>
+    public bool UseLz4Compression { get; set; } = true;
+}

--- a/tests/Endpoint.Engineering.Cli.UnitTests/Commands/MessagingAddRequestHandlerTests.cs
+++ b/tests/Endpoint.Engineering.Cli.UnitTests/Commands/MessagingAddRequestHandlerTests.cs
@@ -1,0 +1,310 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Endpoint.Artifacts.Abstractions;
+using Endpoint.Engineering.Cli.Commands;
+using Endpoint.Engineering.RedisPubSub.Artifacts;
+using Endpoint.Engineering.RedisPubSub.Models;
+using Endpoint.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Endpoint.Engineering.Cli.UnitTests.Commands;
+
+public class MessagingAddRequestHandlerTests
+{
+    private readonly Mock<ILogger<MessagingAddRequestHandler>> _loggerMock;
+    private readonly Mock<IFileProvider> _fileProviderMock;
+    private readonly MockFileSystem _fileSystem;
+    private readonly Mock<IArtifactFactory> _artifactFactoryMock;
+    private readonly Mock<IArtifactGenerator> _artifactGeneratorMock;
+    private readonly MessagingAddRequestHandler _handler;
+
+    public MessagingAddRequestHandlerTests()
+    {
+        _loggerMock = new Mock<ILogger<MessagingAddRequestHandler>>();
+        _fileProviderMock = new Mock<IFileProvider>();
+        _fileSystem = new MockFileSystem();
+        _artifactFactoryMock = new Mock<IArtifactFactory>();
+        _artifactGeneratorMock = new Mock<IArtifactGenerator>();
+
+        _handler = new MessagingAddRequestHandler(
+            _loggerMock.Object,
+            _fileProviderMock.Object,
+            _fileSystem,
+            _artifactFactoryMock.Object,
+            _artifactGeneratorMock.Object);
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrowArgumentNullException_WhenLoggerIsNull()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new MessagingAddRequestHandler(
+            null!,
+            _fileProviderMock.Object,
+            _fileSystem,
+            _artifactFactoryMock.Object,
+            _artifactGeneratorMock.Object));
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrowArgumentNullException_WhenFileProviderIsNull()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new MessagingAddRequestHandler(
+            _loggerMock.Object,
+            null!,
+            _fileSystem,
+            _artifactFactoryMock.Object,
+            _artifactGeneratorMock.Object));
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrowArgumentNullException_WhenFileSystemIsNull()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new MessagingAddRequestHandler(
+            _loggerMock.Object,
+            _fileProviderMock.Object,
+            null!,
+            _artifactFactoryMock.Object,
+            _artifactGeneratorMock.Object));
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrowArgumentNullException_WhenArtifactFactoryIsNull()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new MessagingAddRequestHandler(
+            _loggerMock.Object,
+            _fileProviderMock.Object,
+            _fileSystem,
+            null!,
+            _artifactGeneratorMock.Object));
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrowArgumentNullException_WhenArtifactGeneratorIsNull()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new MessagingAddRequestHandler(
+            _loggerMock.Object,
+            _fileProviderMock.Object,
+            _fileSystem,
+            _artifactFactoryMock.Object,
+            null!));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrowInvalidOperationException_WhenNoSolutionFileFound()
+    {
+        // Arrange
+        var request = new MessagingAddRequest
+        {
+            Directory = "/test/path"
+        };
+
+        _fileProviderMock.Setup(x => x.Get("*.sln", request.Directory, 0))
+            .Returns(Endpoint.Constants.FileNotFound);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _handler.Handle(request, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseSolutionNameFromFile_WhenNameNotProvided()
+    {
+        // Arrange
+        var request = new MessagingAddRequest
+        {
+            Directory = "/test/path"
+        };
+
+        var solutionPath = "/test/path/MyApp.sln";
+        _fileProviderMock.Setup(x => x.Get("*.sln", request.Directory, 0))
+            .Returns(solutionPath);
+
+        var projectModel = new MessagingProjectModel("MyApp", "/test/path");
+        _artifactFactoryMock.Setup(x => x.CreateMessagingProjectAsync(It.Is<MessagingModel>(m => m.SolutionName == "MyApp"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(projectModel);
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _artifactFactoryMock.Verify(x => x.CreateMessagingProjectAsync(
+            It.Is<MessagingModel>(m => m.SolutionName == "MyApp"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseProvidedName_WhenNameIsProvided()
+    {
+        // Arrange
+        var request = new MessagingAddRequest
+        {
+            Name = "CustomName",
+            Directory = "/test/path"
+        };
+
+        var solutionPath = "/test/path/MyApp.sln";
+        _fileProviderMock.Setup(x => x.Get("*.sln", request.Directory, 0))
+            .Returns(solutionPath);
+
+        var projectModel = new MessagingProjectModel("CustomName", "/test/path");
+        _artifactFactoryMock.Setup(x => x.CreateMessagingProjectAsync(It.Is<MessagingModel>(m => m.SolutionName == "CustomName"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(projectModel);
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _artifactFactoryMock.Verify(x => x.CreateMessagingProjectAsync(
+            It.Is<MessagingModel>(m => m.SolutionName == "CustomName"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldPassUseLz4Compression_ToMessagingModel()
+    {
+        // Arrange
+        var request = new MessagingAddRequest
+        {
+            Directory = "/test/path",
+            UseLz4Compression = false
+        };
+
+        var solutionPath = "/test/path/TestApp.sln";
+        _fileProviderMock.Setup(x => x.Get("*.sln", request.Directory, 0))
+            .Returns(solutionPath);
+
+        var projectModel = new MessagingProjectModel("TestApp", "/test/path");
+        _artifactFactoryMock.Setup(x => x.CreateMessagingProjectAsync(It.IsAny<MessagingModel>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(projectModel);
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _artifactFactoryMock.Verify(x => x.CreateMessagingProjectAsync(
+            It.Is<MessagingModel>(m => m.UseLz4Compression == false),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallArtifactGenerator_WithProjectModel()
+    {
+        // Arrange
+        var request = new MessagingAddRequest
+        {
+            Directory = "/test/path"
+        };
+
+        var solutionPath = "/test/path/TestApp.sln";
+        _fileProviderMock.Setup(x => x.Get("*.sln", request.Directory, 0))
+            .Returns(solutionPath);
+
+        var projectModel = new MessagingProjectModel("TestApp", "/test/path");
+        _artifactFactoryMock.Setup(x => x.CreateMessagingProjectAsync(It.IsAny<MessagingModel>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(projectModel);
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _artifactGeneratorMock.Verify(x => x.GenerateAsync(projectModel, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseSrcDirectory_WhenItExists()
+    {
+        // Arrange
+        var request = new MessagingAddRequest
+        {
+            Directory = "/test/path"
+        };
+
+        var solutionPath = "/test/path/TestApp.sln";
+        _fileProviderMock.Setup(x => x.Get("*.sln", request.Directory, 0))
+            .Returns(solutionPath);
+
+        _fileSystem.AddDirectory("/test/path/src");
+
+        var projectModel = new MessagingProjectModel("TestApp", "/test/path/src");
+        _artifactFactoryMock.Setup(x => x.CreateMessagingProjectAsync(It.Is<MessagingModel>(m => m.Directory == "/test/path/src"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(projectModel);
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _artifactFactoryMock.Verify(x => x.CreateMessagingProjectAsync(
+            It.Is<MessagingModel>(m => m.Directory == "/test/path/src"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseSolutionDirectory_WhenSrcDoesNotExist()
+    {
+        // Arrange
+        var request = new MessagingAddRequest
+        {
+            Directory = "/test/path"
+        };
+
+        var solutionPath = "/test/path/TestApp.sln";
+        _fileProviderMock.Setup(x => x.Get("*.sln", request.Directory, 0))
+            .Returns(solutionPath);
+
+        // Note: Not adding /test/path/src to file system
+
+        var projectModel = new MessagingProjectModel("TestApp", "/test/path");
+        _artifactFactoryMock.Setup(x => x.CreateMessagingProjectAsync(It.Is<MessagingModel>(m => m.Directory == "/test/path"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(projectModel);
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _artifactFactoryMock.Verify(x => x.CreateMessagingProjectAsync(
+            It.Is<MessagingModel>(m => m.Directory == "/test/path"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+
+public class MessagingAddRequestTests
+{
+    [Fact]
+    public void Directory_ShouldDefaultToCurrentDirectory()
+    {
+        // Arrange & Act
+        var request = new MessagingAddRequest();
+
+        // Assert
+        Assert.Equal(Environment.CurrentDirectory, request.Directory);
+    }
+
+    [Fact]
+    public void UseLz4Compression_ShouldDefaultToTrue()
+    {
+        // Arrange & Act
+        var request = new MessagingAddRequest();
+
+        // Assert
+        Assert.True(request.UseLz4Compression);
+    }
+
+    [Fact]
+    public void Name_ShouldDefaultToNull()
+    {
+        // Arrange & Act
+        var request = new MessagingAddRequest();
+
+        // Assert
+        Assert.Null(request.Name);
+    }
+}

--- a/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Artifacts/ArtifactFactoryTests.cs
+++ b/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Artifacts/ArtifactFactoryTests.cs
@@ -1,0 +1,353 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Endpoint.Engineering.RedisPubSub.Artifacts;
+using Endpoint.Engineering.RedisPubSub.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Endpoint.Engineering.UnitTests.RedisPubSub.Artifacts;
+
+public class ArtifactFactoryTests
+{
+    private readonly Mock<ILogger<ArtifactFactory>> _loggerMock;
+    private readonly MockFileSystem _fileSystem;
+    private readonly ArtifactFactory _factory;
+
+    public ArtifactFactoryTests()
+    {
+        _loggerMock = new Mock<ILogger<ArtifactFactory>>();
+        _fileSystem = new MockFileSystem();
+        _factory = new ArtifactFactory(_loggerMock.Object, _fileSystem);
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldReturnProjectModel()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src",
+            UseLz4Compression = true
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("TestApp.Messaging", result.Name);
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldSetCorrectSolutionName()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "MyProject",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Equal("MyProject", result.SolutionName);
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldSetUseLz4Compression()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src",
+            UseLz4Compression = false
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.False(result.UseLz4Compression);
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateIMessageFile()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Files, f => f.Name == "IMessage");
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateIDomainEventFile()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Files, f => f.Name == "IDomainEvent");
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateICommandFile()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Files, f => f.Name == "ICommand");
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateMessageHeaderFile()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Files, f => f.Name == "MessageHeader");
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateMessageEnvelopeFile()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Files, f => f.Name == "MessageEnvelope");
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateIMessageSerializerFile()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Files, f => f.Name == "IMessageSerializer");
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateMessagePackMessageSerializerFile()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Files, f => f.Name == "MessagePackMessageSerializer");
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateIMessageTypeRegistryFile()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Files, f => f.Name == "IMessageTypeRegistry");
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateMessageTypeRegistryFile()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Files, f => f.Name == "MessageTypeRegistry");
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateConfigureServicesFile()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Files, f => f.Name == "ConfigureServices");
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldCreateTenFiles()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Equal(10, result.Files.Count);
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_WithLz4Compression_ShouldIncludeCompressionInSerializer()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src",
+            UseLz4Compression = true
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        var serializerFile = result.Files.First(f => f.Name == "MessagePackMessageSerializer");
+        Assert.Contains("Lz4BlockArray", serializerFile.Body);
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_WithoutLz4Compression_ShouldNotIncludeCompressionInSerializer()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src",
+            UseLz4Compression = false
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        var serializerFile = result.Files.First(f => f.Name == "MessagePackMessageSerializer");
+        Assert.DoesNotContain("Lz4BlockArray", serializerFile.Body);
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_FilesShouldHaveCorrectNamespaces()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "MyApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        var messageHeaderFile = result.Files.First(f => f.Name == "MessageHeader");
+        Assert.Contains("namespace MyApp.Messaging.Messages", messageHeaderFile.Body);
+    }
+
+    [Fact]
+    public async Task CreateMessagingProjectAsync_ShouldAddMessagePackPackage()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestApp",
+            Directory = "/test/src"
+        };
+
+        // Act
+        var result = await _factory.CreateMessagingProjectAsync(model);
+
+        // Assert
+        Assert.Contains(result.Packages, p => p.Name == "MessagePack");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrowArgumentNullException_WhenLoggerIsNull()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new ArtifactFactory(null!, _fileSystem));
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrowArgumentNullException_WhenFileSystemIsNull()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new ArtifactFactory(_loggerMock.Object, null!));
+    }
+}

--- a/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Artifacts/MessagingProjectModelTests.cs
+++ b/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Artifacts/MessagingProjectModelTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.RedisPubSub.Artifacts;
+using Endpoint.DotNet.Artifacts.Projects.Enums;
+
+namespace Endpoint.Engineering.UnitTests.RedisPubSub.Artifacts;
+
+public class MessagingProjectModelTests
+{
+    [Fact]
+    public void Constructor_WithSolutionName_ShouldSetCorrectProjectName()
+    {
+        // Arrange
+        var solutionName = "MyApplication";
+        var parentDirectory = "/path/to/src";
+
+        // Act
+        var model = new MessagingProjectModel(solutionName, parentDirectory);
+
+        // Assert
+        Assert.Equal("MyApplication.Messaging", model.Name);
+    }
+
+    [Fact]
+    public void Constructor_WithSolutionName_ShouldSetSolutionName()
+    {
+        // Arrange
+        var solutionName = "TestSolution";
+        var parentDirectory = "/path/to/src";
+
+        // Act
+        var model = new MessagingProjectModel(solutionName, parentDirectory);
+
+        // Assert
+        Assert.Equal(solutionName, model.SolutionName);
+    }
+
+    [Fact]
+    public void Constructor_WithSolutionName_ShouldAddMessagePackPackage()
+    {
+        // Arrange
+        var solutionName = "TestSolution";
+        var parentDirectory = "/path/to/src";
+
+        // Act
+        var model = new MessagingProjectModel(solutionName, parentDirectory);
+
+        // Assert
+        Assert.Contains(model.Packages, p => p.Name == "MessagePack");
+    }
+
+    [Fact]
+    public void Constructor_WithSolutionName_ShouldSetProjectTypeToClassLib()
+    {
+        // Arrange
+        var solutionName = "TestSolution";
+        var parentDirectory = "/path/to/src";
+
+        // Act
+        var model = new MessagingProjectModel(solutionName, parentDirectory);
+
+        // Assert
+        Assert.Equal(DotNetProjectType.ClassLib, model.DotNetProjectType);
+    }
+
+    [Fact]
+    public void UseLz4Compression_ShouldDefaultToTrue()
+    {
+        // Arrange
+        var solutionName = "TestSolution";
+        var parentDirectory = "/path/to/src";
+
+        // Act
+        var model = new MessagingProjectModel(solutionName, parentDirectory);
+
+        // Assert
+        Assert.True(model.UseLz4Compression);
+    }
+
+    [Fact]
+    public void UseLz4Compression_ShouldBeSettable()
+    {
+        // Arrange
+        var model = new MessagingProjectModel("Test", "/path")
+        {
+            UseLz4Compression = false
+        };
+
+        // Assert
+        Assert.False(model.UseLz4Compression);
+    }
+
+    [Fact]
+    public void DefaultConstructor_ShouldCreateEmptyModel()
+    {
+        // Arrange & Act
+        var model = new MessagingProjectModel();
+
+        // Assert
+        Assert.Equal(string.Empty, model.SolutionName);
+    }
+
+    [Fact]
+    public void Directory_ShouldBeSetCorrectly()
+    {
+        // Arrange
+        var solutionName = "MyApp";
+        var parentDirectory = "/home/user/src";
+
+        // Act
+        var model = new MessagingProjectModel(solutionName, parentDirectory);
+
+        // Assert
+        Assert.Contains("MyApp.Messaging", model.Directory);
+    }
+
+    [Fact]
+    public void Namespace_ShouldMatchProjectName()
+    {
+        // Arrange
+        var solutionName = "MyApp";
+        var parentDirectory = "/path/to/src";
+
+        // Act
+        var model = new MessagingProjectModel(solutionName, parentDirectory);
+
+        // Assert
+        Assert.Equal("MyApp.Messaging", model.Namespace);
+    }
+}

--- a/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Models/MessageEnvelopeModelTests.cs
+++ b/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Models/MessageEnvelopeModelTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.RedisPubSub.Models;
+
+namespace Endpoint.Engineering.UnitTests.RedisPubSub.Models;
+
+public class MessageEnvelopeModelTests
+{
+    [Fact]
+    public void Name_ShouldDefaultToMessageEnvelope()
+    {
+        // Arrange & Act
+        var model = new MessageEnvelopeModel();
+
+        // Assert
+        Assert.Equal("MessageEnvelope", model.Name);
+    }
+
+    [Fact]
+    public void Namespace_ShouldDefaultToEmptyString()
+    {
+        // Arrange & Act
+        var model = new MessageEnvelopeModel();
+
+        // Assert
+        Assert.Equal(string.Empty, model.Namespace);
+    }
+
+    [Fact]
+    public void GenericPayload_ShouldDefaultToTrue()
+    {
+        // Arrange & Act
+        var model = new MessageEnvelopeModel();
+
+        // Assert
+        Assert.True(model.GenericPayload);
+    }
+
+    [Fact]
+    public void AllProperties_ShouldBeSettable()
+    {
+        // Arrange
+        var model = new MessageEnvelopeModel
+        {
+            Name = "CustomEnvelope",
+            Namespace = "MyApp.Messaging",
+            GenericPayload = false
+        };
+
+        // Assert
+        Assert.Equal("CustomEnvelope", model.Name);
+        Assert.Equal("MyApp.Messaging", model.Namespace);
+        Assert.False(model.GenericPayload);
+    }
+}

--- a/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Models/MessageHeaderModelTests.cs
+++ b/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Models/MessageHeaderModelTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.RedisPubSub.Models;
+
+namespace Endpoint.Engineering.UnitTests.RedisPubSub.Models;
+
+public class MessageHeaderModelTests
+{
+    [Fact]
+    public void SchemaVersion_ShouldDefaultToOne()
+    {
+        // Arrange & Act
+        var model = new MessageHeaderModel();
+
+        // Assert
+        Assert.Equal(1, model.SchemaVersion);
+    }
+
+    [Fact]
+    public void MessageType_ShouldDefaultToEmptyString()
+    {
+        // Arrange & Act
+        var model = new MessageHeaderModel();
+
+        // Assert
+        Assert.Equal(string.Empty, model.MessageType);
+    }
+
+    [Fact]
+    public void MessageId_ShouldDefaultToEmptyString()
+    {
+        // Arrange & Act
+        var model = new MessageHeaderModel();
+
+        // Assert
+        Assert.Equal(string.Empty, model.MessageId);
+    }
+
+    [Fact]
+    public void CorrelationId_ShouldDefaultToEmptyString()
+    {
+        // Arrange & Act
+        var model = new MessageHeaderModel();
+
+        // Assert
+        Assert.Equal(string.Empty, model.CorrelationId);
+    }
+
+    [Fact]
+    public void CausationId_ShouldDefaultToEmptyString()
+    {
+        // Arrange & Act
+        var model = new MessageHeaderModel();
+
+        // Assert
+        Assert.Equal(string.Empty, model.CausationId);
+    }
+
+    [Fact]
+    public void SourceService_ShouldDefaultToEmptyString()
+    {
+        // Arrange & Act
+        var model = new MessageHeaderModel();
+
+        // Assert
+        Assert.Equal(string.Empty, model.SourceService);
+    }
+
+    [Fact]
+    public void TimestampUnixMs_ShouldDefaultToZero()
+    {
+        // Arrange & Act
+        var model = new MessageHeaderModel();
+
+        // Assert
+        Assert.Equal(0, model.TimestampUnixMs);
+    }
+
+    [Fact]
+    public void AllProperties_ShouldBeSettable()
+    {
+        // Arrange
+        var model = new MessageHeaderModel
+        {
+            MessageType = "test.message.v1",
+            MessageId = "msg-123",
+            CorrelationId = "corr-456",
+            CausationId = "cause-789",
+            TimestampUnixMs = 1234567890,
+            SourceService = "test-service",
+            SchemaVersion = 2
+        };
+
+        // Assert
+        Assert.Equal("test.message.v1", model.MessageType);
+        Assert.Equal("msg-123", model.MessageId);
+        Assert.Equal("corr-456", model.CorrelationId);
+        Assert.Equal("cause-789", model.CausationId);
+        Assert.Equal(1234567890, model.TimestampUnixMs);
+        Assert.Equal("test-service", model.SourceService);
+        Assert.Equal(2, model.SchemaVersion);
+    }
+}

--- a/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Models/MessageSerializerModelTests.cs
+++ b/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Models/MessageSerializerModelTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.RedisPubSub.Models;
+
+namespace Endpoint.Engineering.UnitTests.RedisPubSub.Models;
+
+public class MessageSerializerModelTests
+{
+    [Fact]
+    public void Name_ShouldDefaultToMessagePackMessageSerializer()
+    {
+        // Arrange & Act
+        var model = new MessageSerializerModel();
+
+        // Assert
+        Assert.Equal("MessagePackMessageSerializer", model.Name);
+    }
+
+    [Fact]
+    public void Namespace_ShouldDefaultToEmptyString()
+    {
+        // Arrange & Act
+        var model = new MessageSerializerModel();
+
+        // Assert
+        Assert.Equal(string.Empty, model.Namespace);
+    }
+
+    [Fact]
+    public void UseLz4Compression_ShouldDefaultToTrue()
+    {
+        // Arrange & Act
+        var model = new MessageSerializerModel();
+
+        // Assert
+        Assert.True(model.UseLz4Compression);
+    }
+
+    [Fact]
+    public void AllProperties_ShouldBeSettable()
+    {
+        // Arrange
+        var model = new MessageSerializerModel
+        {
+            Name = "CustomSerializer",
+            Namespace = "MyApp.Services",
+            UseLz4Compression = false
+        };
+
+        // Assert
+        Assert.Equal("CustomSerializer", model.Name);
+        Assert.Equal("MyApp.Services", model.Namespace);
+        Assert.False(model.UseLz4Compression);
+    }
+}

--- a/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Models/MessageTypeRegistryModelTests.cs
+++ b/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Models/MessageTypeRegistryModelTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.RedisPubSub.Models;
+
+namespace Endpoint.Engineering.UnitTests.RedisPubSub.Models;
+
+public class MessageTypeRegistryModelTests
+{
+    [Fact]
+    public void Name_ShouldDefaultToMessageTypeRegistry()
+    {
+        // Arrange & Act
+        var model = new MessageTypeRegistryModel();
+
+        // Assert
+        Assert.Equal("MessageTypeRegistry", model.Name);
+    }
+
+    [Fact]
+    public void Namespace_ShouldDefaultToEmptyString()
+    {
+        // Arrange & Act
+        var model = new MessageTypeRegistryModel();
+
+        // Assert
+        Assert.Equal(string.Empty, model.Namespace);
+    }
+
+    [Fact]
+    public void AllProperties_ShouldBeSettable()
+    {
+        // Arrange
+        var model = new MessageTypeRegistryModel
+        {
+            Name = "CustomRegistry",
+            Namespace = "MyApp.Services"
+        };
+
+        // Assert
+        Assert.Equal("CustomRegistry", model.Name);
+        Assert.Equal("MyApp.Services", model.Namespace);
+    }
+}

--- a/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Models/MessagingModelTests.cs
+++ b/tests/Endpoint.Engineering.UnitTests/RedisPubSub/Models/MessagingModelTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.RedisPubSub.Models;
+
+namespace Endpoint.Engineering.UnitTests.RedisPubSub.Models;
+
+public class MessagingModelTests
+{
+    [Fact]
+    public void ProjectName_ShouldBeSolutionNamePlusMessaging()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "MyApp"
+        };
+
+        // Act
+        var projectName = model.ProjectName;
+
+        // Assert
+        Assert.Equal("MyApp.Messaging", projectName);
+    }
+
+    [Fact]
+    public void Namespace_ShouldEqualProjectName()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            SolutionName = "TestSolution"
+        };
+
+        // Act
+        var @namespace = model.Namespace;
+
+        // Assert
+        Assert.Equal("TestSolution.Messaging", @namespace);
+    }
+
+    [Fact]
+    public void UseLz4Compression_ShouldDefaultToTrue()
+    {
+        // Arrange & Act
+        var model = new MessagingModel();
+
+        // Assert
+        Assert.True(model.UseLz4Compression);
+    }
+
+    [Fact]
+    public void UseLz4Compression_ShouldBeSettable()
+    {
+        // Arrange
+        var model = new MessagingModel
+        {
+            UseLz4Compression = false
+        };
+
+        // Assert
+        Assert.False(model.UseLz4Compression);
+    }
+
+    [Fact]
+    public void Directory_ShouldBeSettable()
+    {
+        // Arrange
+        var expectedDirectory = "/path/to/project";
+        var model = new MessagingModel
+        {
+            Directory = expectedDirectory
+        };
+
+        // Assert
+        Assert.Equal(expectedDirectory, model.Directory);
+    }
+
+    [Fact]
+    public void SolutionName_ShouldDefaultToEmptyString()
+    {
+        // Arrange & Act
+        var model = new MessagingModel();
+
+        // Assert
+        Assert.Equal(string.Empty, model.SolutionName);
+    }
+}


### PR DESCRIPTION
Add a new CLI command 'messaging-add' that generates a {SolutionName}.Messaging
project with MessagePack serialization support for high-performance messaging.

Features:
- MessageHeader and MessageEnvelope classes with MessagePack attributes
- IMessage, IDomainEvent, and ICommand interfaces
- IMessageSerializer interface with MessagePackMessageSerializer implementation
- IMessageTypeRegistry for message type registration and lookup
- ConfigureServices extension for easy DI registration
- Optional LZ4 compression support

Also includes:
- RedisPubSub models and artifact factory in Endpoint.Engineering
- MessagingDemo playground project for demonstration
- Comprehensive unit tests (80%+ coverage target)
- Documentation template for command artifact generation