### PR TITLE
Add Messaging project generator with MessagePack and Redis pub/sub support

### DIFF
--- a/playground/MessagingProjectDemo/MessagingProjectDemo.csproj
+++ b/playground/MessagingProjectDemo/MessagingProjectDemo.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>1998,4014,SA1101,SA1600,SA1200,SA1633,1591,SA1309</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Endpoint\Endpoint.csproj" />
+    <ProjectReference Include="..\..\src\Endpoint.Engineering.Cli\Endpoint.Engineering.Cli.csproj" />
+    <ProjectReference Include="..\..\src\Endpoint.DotNet\Endpoint.DotNet.csproj" />
+    <ProjectReference Include="..\..\src\Endpoint.Engineering\Endpoint.Engineering.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="12.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="messages.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="notifications-messages.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/playground/MessagingProjectDemo/Program.cs
+++ b/playground/MessagingProjectDemo/Program.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint;
+using Endpoint.Artifacts.Abstractions;
+using Endpoint.Engineering.Cli.Commands;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+// Setup dependency injection
+var services = new ServiceCollection();
+
+// Add logging
+services.AddLogging(builder =>
+{
+    builder.AddConsole();
+    builder.SetMinimumLevel(LogLevel.Information);
+});
+
+// Add MediatR and scan the assembly containing MessagingProjectAddRequest
+services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<MessagingProjectAddRequest>());
+
+// Add core services from Endpoint assembly
+services.AddCoreServices(typeof(IArtifactGenerator).Assembly);
+
+// Add DotNet services
+services.AddDotNetServices();
+
+// Add Engineering services (includes MessagingArtifactFactory)
+services.AddEngineeringServices();
+
+var serviceProvider = services.BuildServiceProvider();
+
+var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
+var mediator = serviceProvider.GetRequiredService<IMediator>();
+
+try
+{
+    // Output directory for the demo solution (repo root/generated-output)
+    var repoRoot = Path.Combine(Directory.GetCurrentDirectory(), "..", "..");
+    var demoDirectory = Path.Combine(repoRoot, "generated-output", "messaging-demo");
+
+    // Clean up existing demo directory if it exists
+    if (Directory.Exists(demoDirectory))
+    {
+        logger.LogInformation("Cleaning up existing demo directory: {Directory}", demoDirectory);
+        Directory.Delete(demoDirectory, recursive: true);
+    }
+
+    Directory.CreateDirectory(demoDirectory);
+
+    logger.LogInformation("=== MessagingProjectAdd Demo ===");
+    logger.LogInformation("Output directory: {Directory}", demoDirectory);
+
+    // Get the path to the message definition files
+    var messagesFilePath = Path.Combine(Directory.GetCurrentDirectory(), "messages.json");
+    var notificationsFilePath = Path.Combine(Directory.GetCurrentDirectory(), "notifications-messages.json");
+
+    logger.LogInformation("");
+    logger.LogInformation("=== Demo 1: Generate sample definition file ===");
+
+    // First, demonstrate generating a sample definition file
+    var sampleRequest = new MessagingProjectAddRequest
+    {
+        GenerateSample = true,
+        Directory = demoDirectory
+    };
+
+    await mediator.Send(sampleRequest);
+
+    logger.LogInformation("");
+    logger.LogInformation("=== Demo 2: Create messaging project from single file ===");
+
+    // Create a messaging project from the messages.json file
+    var singleFileRequest = new MessagingProjectAddRequest
+    {
+        FilePath = messagesFilePath,
+        Directory = demoDirectory
+    };
+
+    await mediator.Send(singleFileRequest);
+
+    // Clean up for next demo
+    var projectDir = Path.Combine(demoDirectory, "src", "ECommerce.Messaging");
+    if (Directory.Exists(projectDir))
+    {
+        Directory.Delete(projectDir, recursive: true);
+    }
+
+    logger.LogInformation("");
+    logger.LogInformation("=== Demo 3: Create messaging project from multiple files ===");
+
+    // Create a messaging project from multiple definition files
+    var multiFileRequest = new MessagingProjectAddRequest
+    {
+        Paths = new[] { messagesFilePath, notificationsFilePath },
+        Directory = demoDirectory
+    };
+
+    await mediator.Send(multiFileRequest);
+
+    // Clean up for next demo
+    if (Directory.Exists(projectDir))
+    {
+        Directory.Delete(projectDir, recursive: true);
+    }
+
+    logger.LogInformation("");
+    logger.LogInformation("=== Demo 4: Create basic messaging project without definition file ===");
+
+    // Create a basic messaging project without a definition file
+    var basicRequest = new MessagingProjectAddRequest
+    {
+        Name = "MyMicroservices",
+        IncludeRedisPubSub = true,
+        UseLz4Compression = true,
+        Directory = demoDirectory
+    };
+
+    await mediator.Send(basicRequest);
+
+    logger.LogInformation("");
+    logger.LogInformation("=== Demo Complete ===");
+    logger.LogInformation("Generated files are located at: {Directory}", demoDirectory);
+
+    // List generated files
+    logger.LogInformation("");
+    logger.LogInformation("Generated project structure:");
+    PrintDirectoryTree(demoDirectory, "", logger);
+}
+catch (Exception ex)
+{
+    logger.LogError(ex, "Error during MessagingProjectAdd demo");
+}
+
+static void PrintDirectoryTree(string path, string indent, ILogger logger)
+{
+    var dirInfo = new DirectoryInfo(path);
+
+    foreach (var dir in dirInfo.GetDirectories())
+    {
+        logger.LogInformation("{Indent}{DirName}/", indent, dir.Name);
+        PrintDirectoryTree(dir.FullName, indent + "  ", logger);
+    }
+
+    foreach (var file in dirInfo.GetFiles())
+    {
+        logger.LogInformation("{Indent}{FileName}", indent, file.Name);
+    }
+}

--- a/playground/MessagingProjectDemo/messages.json
+++ b/playground/MessagingProjectDemo/messages.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "https://endpoint.dev/schemas/messaging/v1.0.json",
+  "projectName": "ECommerce",
+  "namespace": "ECommerce.Messaging",
+  "description": "Shared messaging project for e-commerce microservices",
+  "version": "1.0.0",
+  "useLz4Compression": true,
+  "includeRedisPubSub": true,
+  "messages": [
+    {
+      "name": "OrderCreated",
+      "kind": "Event",
+      "messageType": "com.ecommerce.orders.v1.OrderCreated",
+      "description": "Event raised when a new order is created in the system",
+      "schemaVersion": 1,
+      "aggregateType": "Order",
+      "channel": "orders",
+      "properties": [
+        {
+          "name": "OrderId",
+          "type": "Guid",
+          "required": true,
+          "description": "The unique identifier of the order"
+        },
+        {
+          "name": "CustomerId",
+          "type": "Guid",
+          "required": true,
+          "description": "The customer who placed the order"
+        },
+        {
+          "name": "TotalAmount",
+          "type": "decimal",
+          "required": true,
+          "description": "The total amount of the order"
+        },
+        {
+          "name": "Currency",
+          "type": "string",
+          "required": true,
+          "defaultValue": "\"USD\"",
+          "description": "The currency code"
+        },
+        {
+          "name": "OrderItems",
+          "type": "string",
+          "isCollection": true,
+          "collectionType": "List",
+          "description": "The item IDs in the order"
+        }
+      ]
+    },
+    {
+      "name": "OrderShipped",
+      "kind": "Event",
+      "messageType": "com.ecommerce.orders.v1.OrderShipped",
+      "description": "Event raised when an order is shipped",
+      "aggregateType": "Order",
+      "channel": "orders",
+      "properties": [
+        {
+          "name": "OrderId",
+          "type": "Guid",
+          "required": true,
+          "description": "The order that was shipped"
+        },
+        {
+          "name": "TrackingNumber",
+          "type": "string",
+          "required": true,
+          "description": "The shipping tracking number"
+        },
+        {
+          "name": "Carrier",
+          "type": "string",
+          "required": true,
+          "description": "The shipping carrier name"
+        },
+        {
+          "name": "EstimatedDelivery",
+          "type": "DateTimeOffset",
+          "nullable": true,
+          "description": "The estimated delivery date"
+        }
+      ]
+    },
+    {
+      "name": "OrderCancelled",
+      "kind": "Event",
+      "messageType": "com.ecommerce.orders.v1.OrderCancelled",
+      "description": "Event raised when an order is cancelled",
+      "aggregateType": "Order",
+      "channel": "orders",
+      "properties": [
+        {
+          "name": "OrderId",
+          "type": "Guid",
+          "required": true
+        },
+        {
+          "name": "Reason",
+          "type": "string",
+          "required": true,
+          "description": "The cancellation reason"
+        },
+        {
+          "name": "RefundAmount",
+          "type": "decimal",
+          "nullable": true,
+          "description": "The amount to refund"
+        }
+      ]
+    },
+    {
+      "name": "ProcessPayment",
+      "kind": "Command",
+      "messageType": "com.ecommerce.payments.v1.ProcessPayment",
+      "description": "Command to process a payment for an order",
+      "channel": "payments",
+      "properties": [
+        {
+          "name": "PaymentId",
+          "type": "Guid",
+          "required": true,
+          "description": "The payment identifier"
+        },
+        {
+          "name": "OrderId",
+          "type": "Guid",
+          "required": true,
+          "description": "The order to pay for"
+        },
+        {
+          "name": "Amount",
+          "type": "decimal",
+          "required": true,
+          "description": "The payment amount"
+        },
+        {
+          "name": "Currency",
+          "type": "string",
+          "required": true,
+          "defaultValue": "\"USD\""
+        },
+        {
+          "name": "PaymentMethod",
+          "type": "string",
+          "required": true,
+          "description": "The payment method (e.g., CreditCard, PayPal)"
+        }
+      ]
+    },
+    {
+      "name": "PaymentProcessed",
+      "kind": "Event",
+      "messageType": "com.ecommerce.payments.v1.PaymentProcessed",
+      "description": "Event raised when a payment is successfully processed",
+      "aggregateType": "Payment",
+      "channel": "payments",
+      "properties": [
+        {
+          "name": "PaymentId",
+          "type": "Guid",
+          "required": true
+        },
+        {
+          "name": "OrderId",
+          "type": "Guid",
+          "required": true
+        },
+        {
+          "name": "Amount",
+          "type": "decimal",
+          "required": true
+        },
+        {
+          "name": "TransactionId",
+          "type": "string",
+          "required": true,
+          "description": "The external transaction reference"
+        }
+      ]
+    },
+    {
+      "name": "InventoryReserved",
+      "kind": "Event",
+      "messageType": "com.ecommerce.inventory.v1.InventoryReserved",
+      "description": "Event raised when inventory is reserved for an order",
+      "aggregateType": "Inventory",
+      "channel": "inventory",
+      "properties": [
+        {
+          "name": "ReservationId",
+          "type": "Guid",
+          "required": true
+        },
+        {
+          "name": "OrderId",
+          "type": "Guid",
+          "required": true
+        },
+        {
+          "name": "ProductId",
+          "type": "Guid",
+          "required": true
+        },
+        {
+          "name": "Quantity",
+          "type": "int",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "channels": [
+    {
+      "name": "orders",
+      "description": "Channel for order-related events",
+      "publishedMessages": ["OrderCreated", "OrderShipped", "OrderCancelled"]
+    },
+    {
+      "name": "payments",
+      "description": "Channel for payment-related messages",
+      "publishedMessages": ["PaymentProcessed"],
+      "subscribedMessages": ["ProcessPayment"]
+    },
+    {
+      "name": "inventory",
+      "description": "Channel for inventory-related events",
+      "publishedMessages": ["InventoryReserved"]
+    }
+  ]
+}

--- a/playground/MessagingProjectDemo/notifications-messages.json
+++ b/playground/MessagingProjectDemo/notifications-messages.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://endpoint.dev/schemas/messaging/v1.0.json",
+  "projectName": "ECommerce",
+  "description": "Additional notification messages for e-commerce",
+  "messages": [
+    {
+      "name": "SendEmailNotification",
+      "kind": "Command",
+      "messageType": "com.ecommerce.notifications.v1.SendEmailNotification",
+      "description": "Command to send an email notification to a customer",
+      "channel": "notifications",
+      "properties": [
+        {
+          "name": "NotificationId",
+          "type": "Guid",
+          "required": true
+        },
+        {
+          "name": "RecipientEmail",
+          "type": "string",
+          "required": true,
+          "description": "The recipient email address"
+        },
+        {
+          "name": "Subject",
+          "type": "string",
+          "required": true,
+          "description": "The email subject"
+        },
+        {
+          "name": "Body",
+          "type": "string",
+          "required": true,
+          "description": "The email body (HTML supported)"
+        },
+        {
+          "name": "TemplateId",
+          "type": "string",
+          "nullable": true,
+          "description": "Optional email template ID"
+        }
+      ]
+    },
+    {
+      "name": "EmailNotificationSent",
+      "kind": "Event",
+      "messageType": "com.ecommerce.notifications.v1.EmailNotificationSent",
+      "description": "Event raised when an email notification is sent",
+      "aggregateType": "Notification",
+      "channel": "notifications",
+      "properties": [
+        {
+          "name": "NotificationId",
+          "type": "Guid",
+          "required": true
+        },
+        {
+          "name": "RecipientEmail",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "DeliveryStatus",
+          "type": "string",
+          "required": true,
+          "description": "The delivery status (Sent, Delivered, Failed)"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Endpoint.Engineering.Cli/Commands/MessagingProjectAdd.cs
+++ b/src/Endpoint.Engineering.Cli/Commands/MessagingProjectAdd.cs
@@ -1,0 +1,333 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using CommandLine;
+using Endpoint.Artifacts.Abstractions;
+using Endpoint.DotNet.Artifacts.Projects.Services;
+using Endpoint.DotNet.Services;
+using Endpoint.Engineering.Messaging.Artifacts;
+using Endpoint.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.Cli.Commands;
+
+/// <summary>
+/// Command to add a shared Messaging project to a solution.
+/// </summary>
+[Verb("messaging-project-add", HelpText = "Add a shared Messaging project with Redis pub/sub and MessagePack support")]
+public class MessagingProjectAddRequest : IRequest
+{
+    /// <summary>
+    /// Gets or sets the path to a JSON file containing message definitions.
+    /// </summary>
+    [Option('f', "file", Required = false, HelpText = "Path to a JSON file containing message definitions")]
+    public string? FilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the paths to multiple JSON files containing message definitions.
+    /// </summary>
+    [Option('p', "paths", Required = false, Separator = ',', HelpText = "Comma-separated paths to JSON files containing message definitions")]
+    public IEnumerable<string>? Paths { get; set; }
+
+    /// <summary>
+    /// Gets or sets the directory where the messaging project will be created.
+    /// </summary>
+    [Option('d', "directory", Required = false, HelpText = "Directory where the messaging project will be created")]
+    public string Directory { get; set; } = Environment.CurrentDirectory;
+
+    /// <summary>
+    /// Gets or sets the project name (without .Messaging suffix).
+    /// </summary>
+    [Option('n', "name", Required = false, HelpText = "Project name (without .Messaging suffix). Required if not using a definition file.")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to include Redis pub/sub support.
+    /// </summary>
+    [Option("include-redis", Required = false, Default = true, HelpText = "Include Redis pub/sub support")]
+    public bool IncludeRedisPubSub { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to use LZ4 compression with MessagePack.
+    /// </summary>
+    [Option("use-compression", Required = false, Default = true, HelpText = "Use LZ4 compression with MessagePack")]
+    public bool UseLz4Compression { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to generate a sample definition file.
+    /// </summary>
+    [Option("generate-sample", Required = false, Default = false, HelpText = "Generate a sample message definition JSON file")]
+    public bool GenerateSample { get; set; }
+}
+
+/// <summary>
+/// Handler for the MessagingProjectAddRequest command.
+/// </summary>
+public class MessagingProjectAddRequestHandler : IRequestHandler<MessagingProjectAddRequest>
+{
+    private readonly ILogger<MessagingProjectAddRequestHandler> _logger;
+    private readonly IMessagingArtifactFactory _messagingFactory;
+    private readonly IProjectService _projectService;
+    private readonly IFileSystem _fileSystem;
+    private readonly IFileProvider _fileProvider;
+    private readonly IArtifactGenerator _artifactGenerator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagingProjectAddRequestHandler"/> class.
+    /// </summary>
+    public MessagingProjectAddRequestHandler(
+        ILogger<MessagingProjectAddRequestHandler> logger,
+        IMessagingArtifactFactory messagingFactory,
+        IProjectService projectService,
+        IFileSystem fileSystem,
+        IFileProvider fileProvider,
+        IArtifactGenerator artifactGenerator)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _messagingFactory = messagingFactory ?? throw new ArgumentNullException(nameof(messagingFactory));
+        _projectService = projectService ?? throw new ArgumentNullException(nameof(projectService));
+        _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+        _fileProvider = fileProvider ?? throw new ArgumentNullException(nameof(fileProvider));
+        _artifactGenerator = artifactGenerator ?? throw new ArgumentNullException(nameof(artifactGenerator));
+    }
+
+    /// <inheritdoc/>
+    public async Task Handle(MessagingProjectAddRequest request, CancellationToken cancellationToken)
+    {
+        if (request.GenerateSample)
+        {
+            await GenerateSampleDefinitionFile(request.Directory, cancellationToken);
+            return;
+        }
+
+        var filePaths = GetFilePaths(request);
+
+        if (filePaths.Count == 0 && string.IsNullOrWhiteSpace(request.Name))
+        {
+            _logger.LogError("Either a definition file path (-f or -p) or project name (-n) is required.");
+            _logger.LogInformation("Use --generate-sample to create a sample message definition file.");
+            return;
+        }
+
+        try
+        {
+            var outputDirectory = ResolveSrcRootDirectory(request.Directory);
+            MessagingProjectModel projectModel;
+
+            if (filePaths.Count > 0)
+            {
+                _logger.LogInformation("Creating messaging project from {FileCount} definition file(s)", filePaths.Count);
+                projectModel = await _messagingFactory.CreateMessagingProjectFromFilesAsync(filePaths, outputDirectory, cancellationToken);
+            }
+            else
+            {
+                _logger.LogInformation("Creating messaging project: {Name}", request.Name);
+                var definition = new Messaging.Models.MessagingProjectDefinition
+                {
+                    ProjectName = request.Name!,
+                    IncludeRedisPubSub = request.IncludeRedisPubSub,
+                    UseLz4Compression = request.UseLz4Compression
+                };
+                projectModel = await _messagingFactory.CreateMessagingProjectAsync(definition, outputDirectory, cancellationToken);
+            }
+
+            // Create project directory
+            _fileSystem.Directory.CreateDirectory(projectModel.Directory);
+
+            // Generate project and files
+            await _artifactGenerator.GenerateAsync(projectModel);
+
+            _logger.LogInformation("Successfully created messaging project: {ProjectName}", projectModel.Name);
+            _logger.LogInformation("  Location: {Directory}", projectModel.Directory);
+            _logger.LogInformation("  Messages: {MessageCount}", projectModel.Messages.Count);
+            _logger.LogInformation("  Redis Pub/Sub: {IncludeRedisPubSub}", projectModel.IncludeRedisPubSub);
+            _logger.LogInformation("  LZ4 Compression: {UseLz4Compression}", projectModel.UseLz4Compression);
+
+            if (projectModel.Messages.Count > 0)
+            {
+                _logger.LogInformation("  Generated messages:");
+                foreach (var message in projectModel.Messages)
+                {
+                    _logger.LogInformation("    - {MessageName} ({MessageKind})", message.Name, message.Kind);
+                }
+            }
+        }
+        catch (FileNotFoundException ex)
+        {
+            _logger.LogError("{Message}", ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating messaging project");
+        }
+    }
+
+    private List<string> GetFilePaths(MessagingProjectAddRequest request)
+    {
+        var paths = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(request.FilePath))
+        {
+            paths.Add(Path.GetFullPath(request.FilePath));
+        }
+
+        if (request.Paths != null)
+        {
+            paths.AddRange(request.Paths.Select(p => Path.GetFullPath(p.Trim())));
+        }
+
+        return paths;
+    }
+
+    private string ResolveSrcRootDirectory(string directory)
+    {
+        var solutionPath = _fileProvider.Get("*.sln", directory, 0);
+
+        var baseDirectory = solutionPath == Endpoint.Constants.FileNotFound
+            ? directory
+            : _fileSystem.Path.GetDirectoryName(solutionPath)!;
+
+        var srcDirectory = _fileSystem.Path.Combine(baseDirectory, "src");
+
+        if (!_fileSystem.Directory.Exists(srcDirectory))
+        {
+            _fileSystem.Directory.CreateDirectory(srcDirectory);
+        }
+
+        _logger.LogInformation("Creating messaging project under: {SrcDirectory}", srcDirectory);
+
+        return srcDirectory;
+    }
+
+    private async Task GenerateSampleDefinitionFile(string directory, CancellationToken cancellationToken)
+    {
+        var sampleContent = """
+            {
+              "$schema": "https://endpoint.dev/schemas/messaging/v1.0.json",
+              "projectName": "MyProject",
+              "namespace": "MyProject.Messaging",
+              "description": "Shared messaging project for microservices communication",
+              "version": "1.0.0",
+              "useLz4Compression": true,
+              "includeRedisPubSub": true,
+              "messages": [
+                {
+                  "name": "OrderCreated",
+                  "kind": "Event",
+                  "messageType": "com.example.orders.v1.OrderCreated",
+                  "description": "Event raised when a new order is created",
+                  "schemaVersion": 1,
+                  "aggregateType": "Order",
+                  "channel": "orders",
+                  "properties": [
+                    {
+                      "name": "OrderId",
+                      "type": "Guid",
+                      "required": true,
+                      "description": "The unique identifier of the order"
+                    },
+                    {
+                      "name": "CustomerId",
+                      "type": "Guid",
+                      "required": true,
+                      "description": "The customer who placed the order"
+                    },
+                    {
+                      "name": "TotalAmount",
+                      "type": "decimal",
+                      "required": true,
+                      "description": "The total amount of the order"
+                    },
+                    {
+                      "name": "Items",
+                      "type": "OrderItem",
+                      "isCollection": true,
+                      "collectionType": "List",
+                      "description": "The items in the order"
+                    }
+                  ]
+                },
+                {
+                  "name": "OrderShipped",
+                  "kind": "Event",
+                  "messageType": "com.example.orders.v1.OrderShipped",
+                  "description": "Event raised when an order is shipped",
+                  "aggregateType": "Order",
+                  "channel": "orders",
+                  "properties": [
+                    {
+                      "name": "OrderId",
+                      "type": "Guid",
+                      "required": true
+                    },
+                    {
+                      "name": "TrackingNumber",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "name": "Carrier",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "name": "ShippedAt",
+                      "type": "DateTimeOffset",
+                      "required": true
+                    }
+                  ]
+                },
+                {
+                  "name": "ProcessPayment",
+                  "kind": "Command",
+                  "messageType": "com.example.payments.v1.ProcessPayment",
+                  "description": "Command to process a payment for an order",
+                  "channel": "payments",
+                  "properties": [
+                    {
+                      "name": "PaymentId",
+                      "type": "Guid",
+                      "required": true
+                    },
+                    {
+                      "name": "OrderId",
+                      "type": "Guid",
+                      "required": true
+                    },
+                    {
+                      "name": "Amount",
+                      "type": "decimal",
+                      "required": true
+                    },
+                    {
+                      "name": "Currency",
+                      "type": "string",
+                      "required": true,
+                      "defaultValue": "\"USD\""
+                    }
+                  ]
+                }
+              ],
+              "channels": [
+                {
+                  "name": "orders",
+                  "description": "Channel for order-related events",
+                  "publishedMessages": ["OrderCreated", "OrderShipped"]
+                },
+                {
+                  "name": "payments",
+                  "description": "Channel for payment commands",
+                  "subscribedMessages": ["ProcessPayment"]
+                }
+              ]
+            }
+            """;
+
+        var filePath = Path.Combine(directory, "messages.json");
+        await File.WriteAllTextAsync(filePath, sampleContent, cancellationToken);
+
+        _logger.LogInformation("Sample message definition file created: {FilePath}", filePath);
+        _logger.LogInformation("Use 'messaging-project-add -f {FilePath}' to create a messaging project from this file.", filePath);
+    }
+}

--- a/src/Endpoint.Engineering/ConfigureServices.cs
+++ b/src/Endpoint.Engineering/ConfigureServices.cs
@@ -32,6 +32,7 @@ using Endpoint.Engineering.Microservices.TelemetryStreaming;
 using Endpoint.Engineering.Microservices.HistoricalTelemetry;
 using Endpoint.Engineering.Microservices.GitAnalysis;
 using Endpoint.Engineering.Microservices.RealtimeNotification;
+using Endpoint.Engineering.Messaging.Artifacts;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -83,6 +84,9 @@ public static class ConfigureServices
 
         // Register MicroserviceFactory for predefined microservice creation
         services.AddSingleton<IMicroserviceFactory, MicroserviceFactory>();
+
+        // Register Messaging project generator services
+        services.AddMessagingProjectGeneratorServices();
     }
 }
 

--- a/src/Endpoint.Engineering/Messaging/Artifacts/IMessagingArtifactFactory.cs
+++ b/src/Endpoint.Engineering/Messaging/Artifacts/IMessagingArtifactFactory.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.Messaging.Models;
+
+namespace Endpoint.Engineering.Messaging.Artifacts;
+
+/// <summary>
+/// Factory interface for creating messaging project artifacts.
+/// </summary>
+public interface IMessagingArtifactFactory
+{
+    /// <summary>
+    /// Creates a messaging project model from a project definition.
+    /// </summary>
+    /// <param name="definition">The messaging project definition.</param>
+    /// <param name="outputDirectory">The output directory for the project.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation and contains the messaging project model.</returns>
+    Task<MessagingProjectModel> CreateMessagingProjectAsync(
+        MessagingProjectDefinition definition,
+        string outputDirectory,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a messaging project model from one or more definition files.
+    /// </summary>
+    /// <param name="definitionFilePaths">The paths to JSON definition files.</param>
+    /// <param name="outputDirectory">The output directory for the project.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation and contains the messaging project model.</returns>
+    Task<MessagingProjectModel> CreateMessagingProjectFromFilesAsync(
+        IEnumerable<string> definitionFilePaths,
+        string outputDirectory,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Endpoint.Engineering/Messaging/Artifacts/MessagingArtifactFactory.cs
+++ b/src/Endpoint.Engineering/Messaging/Artifacts/MessagingArtifactFactory.cs
@@ -1,0 +1,1203 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO.Abstractions;
+using System.Text.Json;
+using Endpoint.Artifacts;
+using Endpoint.Engineering.Messaging.Models;
+using Microsoft.Extensions.Logging;
+using static Endpoint.DotNet.Constants.FileExtensions;
+
+namespace Endpoint.Engineering.Messaging.Artifacts;
+
+/// <summary>
+/// Factory for creating messaging project artifacts.
+/// </summary>
+public class MessagingArtifactFactory : IMessagingArtifactFactory
+{
+    private readonly ILogger<MessagingArtifactFactory> _logger;
+    private readonly IFileSystem _fileSystem;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagingArtifactFactory"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="fileSystem">The file system abstraction.</param>
+    public MessagingArtifactFactory(ILogger<MessagingArtifactFactory> logger, IFileSystem fileSystem)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(fileSystem);
+
+        _logger = logger;
+        _fileSystem = fileSystem;
+    }
+
+    /// <inheritdoc/>
+    public async Task<MessagingProjectModel> CreateMessagingProjectFromFilesAsync(
+        IEnumerable<string> definitionFilePaths,
+        string outputDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        var allMessages = new List<MessageDefinition>();
+        var allChannels = new List<ChannelDefinition>();
+        MessagingProjectDefinition? primaryDefinition = null;
+
+        foreach (var filePath in definitionFilePaths)
+        {
+            _logger.LogInformation("Reading message definition file: {FilePath}", filePath);
+
+            if (!_fileSystem.File.Exists(filePath))
+            {
+                throw new FileNotFoundException($"Message definition file not found: {filePath}");
+            }
+
+            var json = await _fileSystem.File.ReadAllTextAsync(filePath, cancellationToken);
+            var definition = JsonSerializer.Deserialize<MessagingProjectDefinition>(json, JsonOptions)
+                ?? throw new InvalidOperationException($"Failed to deserialize message definition file: {filePath}");
+
+            primaryDefinition ??= definition;
+            allMessages.AddRange(definition.Messages);
+
+            if (definition.Channels != null)
+            {
+                allChannels.AddRange(definition.Channels);
+            }
+        }
+
+        if (primaryDefinition == null)
+        {
+            throw new InvalidOperationException("No message definition files provided.");
+        }
+
+        // Merge all messages into the primary definition
+        primaryDefinition.Messages = allMessages;
+        if (allChannels.Count > 0)
+        {
+            primaryDefinition.Channels = allChannels;
+        }
+
+        return await CreateMessagingProjectAsync(primaryDefinition, outputDirectory, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<MessagingProjectModel> CreateMessagingProjectAsync(
+        MessagingProjectDefinition definition,
+        string outputDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Creating messaging project: {ProjectName}", definition.ProjectName);
+
+        var projectModel = new MessagingProjectModel(definition.ProjectName, outputDirectory, definition.IncludeRedisPubSub)
+        {
+            UseLz4Compression = definition.UseLz4Compression,
+            Messages = definition.Messages,
+            Channels = definition.Channels
+        };
+
+        var messagesDirectory = _fileSystem.Path.Combine(projectModel.Directory, "Messages");
+        var servicesDirectory = _fileSystem.Path.Combine(projectModel.Directory, "Services");
+        var pubSubDirectory = _fileSystem.Path.Combine(projectModel.Directory, "PubSub");
+
+        // Add base interfaces
+        projectModel.Files.Add(CreateIMessageFile(projectModel.Namespace, messagesDirectory));
+        projectModel.Files.Add(CreateIDomainEventFile(projectModel.Namespace, messagesDirectory));
+        projectModel.Files.Add(CreateICommandFile(projectModel.Namespace, messagesDirectory));
+        projectModel.Files.Add(CreateIQueryFile(projectModel.Namespace, messagesDirectory));
+
+        // Add message infrastructure
+        projectModel.Files.Add(CreateMessageHeaderFile(projectModel.Namespace, messagesDirectory));
+        projectModel.Files.Add(CreateMessageEnvelopeFile(projectModel.Namespace, messagesDirectory));
+
+        // Add serialization services
+        projectModel.Files.Add(CreateIMessageSerializerFile(projectModel.Namespace, servicesDirectory));
+        projectModel.Files.Add(CreateMessagePackMessageSerializerFile(projectModel.Namespace, servicesDirectory, definition.UseLz4Compression));
+        projectModel.Files.Add(CreateIMessageTypeRegistryFile(projectModel.Namespace, servicesDirectory));
+        projectModel.Files.Add(CreateMessageTypeRegistryFile(projectModel.Namespace, servicesDirectory, definition.Messages));
+
+        // Generate message classes from definitions
+        foreach (var message in definition.Messages)
+        {
+            projectModel.Files.Add(CreateMessageFile(projectModel.Namespace, messagesDirectory, message));
+        }
+
+        // Add Redis pub/sub support if enabled
+        if (definition.IncludeRedisPubSub)
+        {
+            projectModel.Files.Add(CreateIMessagePublisherFile(projectModel.Namespace, pubSubDirectory));
+            projectModel.Files.Add(CreateRedisMessagePublisherFile(projectModel.Namespace, pubSubDirectory));
+            projectModel.Files.Add(CreateIMessageSubscriberFile(projectModel.Namespace, pubSubDirectory));
+            projectModel.Files.Add(CreateRedisMessageSubscriberFile(projectModel.Namespace, pubSubDirectory));
+            projectModel.Files.Add(CreateRedisConnectionOptionsFile(projectModel.Namespace, pubSubDirectory));
+        }
+
+        // Add ConfigureServices extension
+        projectModel.Files.Add(CreateConfigureServicesFile(projectModel.Namespace, projectModel.Directory, definition.IncludeRedisPubSub));
+
+        return projectModel;
+    }
+
+    #region Base Interfaces
+
+    private static FileModel CreateIMessageFile(string @namespace, string directory)
+    {
+        return new FileModel("IMessage", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Marker interface for all messages.
+            /// </summary>
+            public interface IMessage
+            {
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateIDomainEventFile(string @namespace, string directory)
+    {
+        return new FileModel("IDomainEvent", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Domain event marker interface.
+            /// </summary>
+            public interface IDomainEvent : IMessage
+            {
+                /// <summary>
+                /// Gets the aggregate ID.
+                /// </summary>
+                string AggregateId { get; }
+
+                /// <summary>
+                /// Gets the aggregate type.
+                /// </summary>
+                string AggregateType { get; }
+
+                /// <summary>
+                /// Gets the timestamp when the event occurred.
+                /// </summary>
+                DateTimeOffset OccurredAt { get; }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateICommandFile(string @namespace, string directory)
+    {
+        return new FileModel("ICommand", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Command marker interface.
+            /// </summary>
+            public interface ICommand : IMessage
+            {
+                /// <summary>
+                /// Gets the target ID.
+                /// </summary>
+                string TargetId { get; }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateIQueryFile(string @namespace, string directory)
+    {
+        return new FileModel("IQuery", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Query marker interface.
+            /// </summary>
+            /// <typeparam name="TResult">The type of the query result.</typeparam>
+            public interface IQuery<TResult> : IMessage
+            {
+            }
+            """
+        };
+    }
+
+    #endregion
+
+    #region Message Infrastructure
+
+    private static FileModel CreateMessageHeaderFile(string @namespace, string directory)
+    {
+        return new FileModel("MessageHeader", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using MessagePack;
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Message header containing metadata for all messages.
+            /// </summary>
+            [MessagePackObject]
+            public sealed class MessageHeader
+            {
+                /// <summary>
+                /// Gets or sets the message type discriminator for deserialization.
+                /// </summary>
+                [Key(0)]
+                public required string MessageType { get; init; }
+
+                /// <summary>
+                /// Gets or sets the message ID for idempotency.
+                /// </summary>
+                [Key(1)]
+                public required string MessageId { get; init; }
+
+                /// <summary>
+                /// Gets or sets the correlation ID for distributed tracing.
+                /// </summary>
+                [Key(2)]
+                public required string CorrelationId { get; init; }
+
+                /// <summary>
+                /// Gets or sets the causation ID for event chain tracking.
+                /// </summary>
+                [Key(3)]
+                public required string CausationId { get; init; }
+
+                /// <summary>
+                /// Gets or sets the timestamp in Unix milliseconds.
+                /// </summary>
+                [Key(4)]
+                public required long TimestampUnixMs { get; init; }
+
+                /// <summary>
+                /// Gets or sets the source service name.
+                /// </summary>
+                [Key(5)]
+                public required string SourceService { get; init; }
+
+                /// <summary>
+                /// Gets or sets the schema version for evolution.
+                /// </summary>
+                [Key(6)]
+                public int SchemaVersion { get; init; } = 1;
+
+                /// <summary>
+                /// Gets or sets the metadata dictionary for extensibility.
+                /// </summary>
+                [Key(7)]
+                public Dictionary<string, string>? Metadata { get; init; }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateMessageEnvelopeFile(string @namespace, string directory)
+    {
+        return new FileModel("MessageEnvelope", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using MessagePack;
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// Message envelope that wraps messages with header metadata.
+            /// </summary>
+            /// <typeparam name="TPayload">The type of the message payload.</typeparam>
+            [MessagePackObject]
+            public sealed class MessageEnvelope<TPayload> where TPayload : IMessage
+            {
+                /// <summary>
+                /// Gets or sets the message header.
+                /// </summary>
+                [Key(0)]
+                public MessageHeader Header { get; init; } = new()
+                {
+                    MessageType = string.Empty,
+                    MessageId = string.Empty,
+                    CorrelationId = string.Empty,
+                    CausationId = string.Empty,
+                    TimestampUnixMs = 0,
+                    SourceService = string.Empty
+                };
+
+                /// <summary>
+                /// Gets or sets the message payload.
+                /// </summary>
+                [Key(1)]
+                public TPayload Payload { get; init; } = default!;
+
+                /// <summary>
+                /// Creates a new message envelope with the specified payload.
+                /// </summary>
+                /// <param name="payload">The message payload.</param>
+                /// <param name="sourceService">The source service name.</param>
+                /// <param name="correlationId">Optional correlation ID.</param>
+                /// <param name="causationId">Optional causation ID.</param>
+                /// <returns>A new message envelope.</returns>
+                public static MessageEnvelope<TPayload> Create(
+                    TPayload payload,
+                    string sourceService,
+                    string? correlationId = null,
+                    string? causationId = null)
+                {
+                    var messageId = Guid.NewGuid().ToString();
+                    return new MessageEnvelope<TPayload>
+                    {
+                        Header = new MessageHeader
+                        {
+                            MessageType = typeof(TPayload).Name,
+                            MessageId = messageId,
+                            CorrelationId = correlationId ?? messageId,
+                            CausationId = causationId ?? messageId,
+                            TimestampUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                            SourceService = sourceService
+                        },
+                        Payload = payload
+                    };
+                }
+            }
+            """
+        };
+    }
+
+    #endregion
+
+    #region Serialization Services
+
+    private static FileModel CreateIMessageSerializerFile(string @namespace, string directory)
+    {
+        return new FileModel("IMessageSerializer", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using {{@namespace}}.Messages;
+
+            namespace {{@namespace}}.Services;
+
+            /// <summary>
+            /// Interface for message serialization.
+            /// </summary>
+            public interface IMessageSerializer
+            {
+                /// <summary>
+                /// Serializes a message envelope to bytes.
+                /// </summary>
+                /// <typeparam name="T">The type of the message payload.</typeparam>
+                /// <param name="envelope">The message envelope to serialize.</param>
+                /// <returns>The serialized bytes.</returns>
+                byte[] Serialize<T>(MessageEnvelope<T> envelope) where T : IMessage;
+
+                /// <summary>
+                /// Deserializes bytes to a message envelope.
+                /// </summary>
+                /// <typeparam name="T">The type of the message payload.</typeparam>
+                /// <param name="data">The bytes to deserialize.</param>
+                /// <returns>The deserialized message envelope, or null if deserialization fails.</returns>
+                MessageEnvelope<T>? Deserialize<T>(ReadOnlyMemory<byte> data) where T : IMessage;
+
+                /// <summary>
+                /// Peeks at the header of a message without fully deserializing the payload.
+                /// </summary>
+                /// <param name="data">The bytes to peek.</param>
+                /// <returns>A tuple containing the header and payload type, or null if peek fails.</returns>
+                (MessageHeader Header, Type? PayloadType)? PeekHeader(ReadOnlyMemory<byte> data);
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateMessagePackMessageSerializerFile(string @namespace, string directory, bool useLz4Compression)
+    {
+        var compressionOption = useLz4Compression
+            ? ".WithCompression(MessagePackCompression.Lz4BlockArray)"
+            : string.Empty;
+
+        return new FileModel("MessagePackMessageSerializer", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using MessagePack;
+            using MessagePack.Resolvers;
+            using {{@namespace}}.Messages;
+
+            namespace {{@namespace}}.Services;
+
+            /// <summary>
+            /// MessagePack-based message serializer implementation.
+            /// </summary>
+            public sealed class MessagePackMessageSerializer : IMessageSerializer
+            {
+                private readonly IMessageTypeRegistry _registry;
+                private static readonly MessagePackSerializerOptions Options = MessagePackSerializerOptions.Standard
+                    .WithResolver(CompositeResolver.Create(
+                        StandardResolver.Instance)){{compressionOption}}
+                    .WithSecurity(MessagePackSecurity.UntrustedData);
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="MessagePackMessageSerializer"/> class.
+                /// </summary>
+                /// <param name="registry">The message type registry.</param>
+                public MessagePackMessageSerializer(IMessageTypeRegistry registry)
+                {
+                    _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+                }
+
+                /// <inheritdoc/>
+                public byte[] Serialize<T>(MessageEnvelope<T> envelope) where T : IMessage
+                {
+                    return MessagePackSerializer.Serialize(envelope, Options);
+                }
+
+                /// <inheritdoc/>
+                public MessageEnvelope<T>? Deserialize<T>(ReadOnlyMemory<byte> data) where T : IMessage
+                {
+                    return MessagePackSerializer.Deserialize<MessageEnvelope<T>>(data, Options);
+                }
+
+                /// <inheritdoc/>
+                public (MessageHeader Header, Type? PayloadType)? PeekHeader(ReadOnlyMemory<byte> data)
+                {
+                    try
+                    {
+                        var reader = new MessagePackReader(data);
+
+                        var mapCount = reader.ReadMapHeader();
+                        for (int i = 0; i < mapCount; i++)
+                        {
+                            var key = reader.ReadString();
+                            if (key == "Header")
+                            {
+                                var header = MessagePackSerializer.Deserialize<MessageHeader>(ref reader, Options);
+                                var payloadType = _registry.GetType(header.MessageType);
+                                return (header, payloadType);
+                            }
+                            reader.Skip();
+                        }
+                        return null;
+                    }
+                    catch
+                    {
+                        return null;
+                    }
+                }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateIMessageTypeRegistryFile(string @namespace, string directory)
+    {
+        return new FileModel("IMessageTypeRegistry", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using {{@namespace}}.Messages;
+
+            namespace {{@namespace}}.Services;
+
+            /// <summary>
+            /// Interface for message type registration and lookup.
+            /// </summary>
+            public interface IMessageTypeRegistry
+            {
+                /// <summary>
+                /// Registers a message type with a message type string.
+                /// </summary>
+                /// <typeparam name="T">The message type.</typeparam>
+                /// <param name="messageType">The message type string.</param>
+                void Register<T>(string messageType) where T : IMessage;
+
+                /// <summary>
+                /// Gets the CLR type for a message type string.
+                /// </summary>
+                /// <param name="messageType">The message type string.</param>
+                /// <returns>The CLR type, or null if not found.</returns>
+                Type? GetType(string messageType);
+
+                /// <summary>
+                /// Gets the message type string for a CLR type.
+                /// </summary>
+                /// <typeparam name="T">The message type.</typeparam>
+                /// <returns>The message type string, or null if not found.</returns>
+                string? GetMessageType<T>() where T : IMessage;
+
+                /// <summary>
+                /// Gets the message type string for a CLR type.
+                /// </summary>
+                /// <param name="type">The CLR type.</param>
+                /// <returns>The message type string, or null if not found.</returns>
+                string? GetMessageType(Type type);
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateMessageTypeRegistryFile(string @namespace, string directory, List<MessageDefinition> messages)
+    {
+        var registrations = string.Join(Environment.NewLine + "        ",
+            messages.Select(m => $"Register<{m.Name}>(\"{m.ComputedMessageType}\");"));
+
+        return new FileModel("MessageTypeRegistry", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using {{@namespace}}.Messages;
+
+            namespace {{@namespace}}.Services;
+
+            /// <summary>
+            /// Implementation of message type registration and lookup.
+            /// </summary>
+            public sealed class MessageTypeRegistry : IMessageTypeRegistry
+            {
+                private readonly Dictionary<string, Type> _typeByName = new();
+                private readonly Dictionary<Type, string> _nameByType = new();
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="MessageTypeRegistry"/> class.
+                /// </summary>
+                public MessageTypeRegistry()
+                {
+                    // Register all known message types
+                    {{registrations}}
+                }
+
+                /// <inheritdoc/>
+                public void Register<T>(string messageType) where T : IMessage
+                {
+                    _typeByName[messageType] = typeof(T);
+                    _nameByType[typeof(T)] = messageType;
+                }
+
+                /// <inheritdoc/>
+                public Type? GetType(string messageType)
+                {
+                    return _typeByName.GetValueOrDefault(messageType);
+                }
+
+                /// <inheritdoc/>
+                public string? GetMessageType<T>() where T : IMessage
+                {
+                    return _nameByType.GetValueOrDefault(typeof(T));
+                }
+
+                /// <inheritdoc/>
+                public string? GetMessageType(Type type)
+                {
+                    return _nameByType.GetValueOrDefault(type);
+                }
+            }
+            """
+        };
+    }
+
+    #endregion
+
+    #region Message Generation
+
+    private static FileModel CreateMessageFile(string @namespace, string directory, MessageDefinition message)
+    {
+        var interfaceType = message.Kind switch
+        {
+            MessageKind.Event => "IDomainEvent",
+            MessageKind.Command => "ICommand",
+            MessageKind.Query => "IMessage",
+            _ => "IMessage"
+        };
+
+        var description = message.Description ?? $"Represents the {message.Name} message.";
+        var properties = GenerateProperties(message);
+        var additionalProperties = GenerateAdditionalInterfaceProperties(message);
+
+        return new FileModel(message.Name, directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using MessagePack;
+
+            namespace {{@namespace}}.Messages;
+
+            /// <summary>
+            /// {{description}}
+            /// </summary>
+            [MessagePackObject]
+            public sealed class {{message.Name}} : {{interfaceType}}
+            {
+            {{properties}}{{additionalProperties}}}
+            """
+        };
+    }
+
+    private static string GenerateProperties(MessageDefinition message)
+    {
+        var properties = new List<string>();
+        var keyIndex = 0;
+
+        foreach (var prop in message.Properties)
+        {
+            var type = GetCSharpType(prop);
+            var nullableMarker = prop.Nullable ? "?" : "";
+            var requiredKeyword = prop.Required && !prop.Nullable ? "required " : "";
+            var defaultValue = GetDefaultValue(prop);
+            var description = prop.Description ?? $"Gets or sets the {prop.Name.ToLowerInvariant()}.";
+
+            properties.Add($$"""
+                /// <summary>
+                /// {{description}}
+                /// </summary>
+                [Key({{keyIndex}})]
+                public {{requiredKeyword}}{{type}}{{nullableMarker}} {{prop.Name}} { get; init; }{{defaultValue}}
+            """);
+
+            keyIndex++;
+        }
+
+        return string.Join(Environment.NewLine + Environment.NewLine, properties);
+    }
+
+    private static string GenerateAdditionalInterfaceProperties(MessageDefinition message)
+    {
+        if (message.Kind == MessageKind.Event)
+        {
+            var hasAggregateId = message.Properties.Any(p => p.Name == "AggregateId");
+            var aggregateType = message.AggregateType ?? "Unknown";
+
+            var additionalProps = new List<string>();
+
+            if (!hasAggregateId)
+            {
+                additionalProps.Add($$"""
+
+                /// <summary>
+                /// Gets the aggregate ID.
+                /// </summary>
+                [IgnoreMember]
+                public string AggregateId => {{GetAggregateIdExpression(message)}};
+            """);
+            }
+
+            additionalProps.Add($$"""
+
+                /// <summary>
+                /// Gets the aggregate type.
+                /// </summary>
+                [IgnoreMember]
+                public string AggregateType => "{{aggregateType}}";
+
+                /// <summary>
+                /// Gets the timestamp when the event occurred.
+                /// </summary>
+                [IgnoreMember]
+                public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
+            """);
+
+            return string.Join(Environment.NewLine, additionalProps);
+        }
+
+        if (message.Kind == MessageKind.Command)
+        {
+            var hasTargetId = message.Properties.Any(p => p.Name == "TargetId");
+            if (!hasTargetId)
+            {
+                return $$"""
+
+
+                /// <summary>
+                /// Gets the target ID.
+                /// </summary>
+                [IgnoreMember]
+                public string TargetId => {{GetTargetIdExpression(message)}};
+            """;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static string GetAggregateIdExpression(MessageDefinition message)
+    {
+        var idProp = message.Properties.FirstOrDefault(p =>
+            p.Name.EndsWith("Id", StringComparison.OrdinalIgnoreCase) &&
+            (p.Type == "Guid" || p.Type == "string"));
+
+        return idProp != null ? $"{idProp.Name}.ToString()" : "Guid.NewGuid().ToString()";
+    }
+
+    private static string GetTargetIdExpression(MessageDefinition message)
+    {
+        var idProp = message.Properties.FirstOrDefault(p =>
+            p.Name.EndsWith("Id", StringComparison.OrdinalIgnoreCase) &&
+            (p.Type == "Guid" || p.Type == "string"));
+
+        return idProp != null ? $"{idProp.Name}.ToString()" : "Guid.NewGuid().ToString()";
+    }
+
+    private static string GetCSharpType(MessagePropertyDefinition prop)
+    {
+        var baseType = prop.Type.ToLowerInvariant() switch
+        {
+            "string" => "string",
+            "int" or "integer" => "int",
+            "long" => "long",
+            "short" => "short",
+            "byte" => "byte",
+            "bool" or "boolean" => "bool",
+            "decimal" => "decimal",
+            "double" => "double",
+            "float" => "float",
+            "guid" => "Guid",
+            "datetime" => "DateTime",
+            "datetimeoffset" => "DateTimeOffset",
+            "timespan" => "TimeSpan",
+            "byte[]" or "bytes" => "byte[]",
+            _ => prop.Type
+        };
+
+        if (prop.IsCollection)
+        {
+            return prop.CollectionType switch
+            {
+                "Array" => $"{baseType}[]",
+                "IEnumerable" => $"IEnumerable<{baseType}>",
+                "IList" => $"IList<{baseType}>",
+                _ => $"List<{baseType}>"
+            };
+        }
+
+        return baseType;
+    }
+
+    private static string GetDefaultValue(MessagePropertyDefinition prop)
+    {
+        if (!string.IsNullOrEmpty(prop.DefaultValue))
+        {
+            return $" = {prop.DefaultValue};";
+        }
+
+        if (prop.IsCollection)
+        {
+            return prop.CollectionType switch
+            {
+                "Array" => $" = Array.Empty<{GetCSharpType(prop with { IsCollection = false })}>();",
+                _ => " = [];"
+            };
+        }
+
+        return "";
+    }
+
+    #endregion
+
+    #region Redis Pub/Sub
+
+    private static FileModel CreateIMessagePublisherFile(string @namespace, string directory)
+    {
+        return new FileModel("IMessagePublisher", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using {{@namespace}}.Messages;
+
+            namespace {{@namespace}}.PubSub;
+
+            /// <summary>
+            /// Interface for publishing messages to Redis pub/sub.
+            /// </summary>
+            public interface IMessagePublisher
+            {
+                /// <summary>
+                /// Publishes a message to the specified channel.
+                /// </summary>
+                /// <typeparam name="T">The type of the message payload.</typeparam>
+                /// <param name="channel">The channel to publish to.</param>
+                /// <param name="message">The message to publish.</param>
+                /// <param name="cancellationToken">The cancellation token.</param>
+                /// <returns>A task that represents the asynchronous operation and contains the number of subscribers that received the message.</returns>
+                Task<long> PublishAsync<T>(string channel, T message, CancellationToken cancellationToken = default) where T : IMessage;
+
+                /// <summary>
+                /// Publishes a message envelope to the specified channel.
+                /// </summary>
+                /// <typeparam name="T">The type of the message payload.</typeparam>
+                /// <param name="channel">The channel to publish to.</param>
+                /// <param name="envelope">The message envelope to publish.</param>
+                /// <param name="cancellationToken">The cancellation token.</param>
+                /// <returns>A task that represents the asynchronous operation and contains the number of subscribers that received the message.</returns>
+                Task<long> PublishEnvelopeAsync<T>(string channel, MessageEnvelope<T> envelope, CancellationToken cancellationToken = default) where T : IMessage;
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateRedisMessagePublisherFile(string @namespace, string directory)
+    {
+        return new FileModel("RedisMessagePublisher", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using Microsoft.Extensions.Logging;
+            using StackExchange.Redis;
+            using {{@namespace}}.Messages;
+            using {{@namespace}}.Services;
+
+            namespace {{@namespace}}.PubSub;
+
+            /// <summary>
+            /// Redis-based message publisher implementation.
+            /// </summary>
+            public sealed class RedisMessagePublisher : IMessagePublisher
+            {
+                private readonly IConnectionMultiplexer _redis;
+                private readonly IMessageSerializer _serializer;
+                private readonly ILogger<RedisMessagePublisher> _logger;
+                private readonly string _serviceName;
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="RedisMessagePublisher"/> class.
+                /// </summary>
+                /// <param name="redis">The Redis connection multiplexer.</param>
+                /// <param name="serializer">The message serializer.</param>
+                /// <param name="logger">The logger.</param>
+                /// <param name="options">The Redis connection options.</param>
+                public RedisMessagePublisher(
+                    IConnectionMultiplexer redis,
+                    IMessageSerializer serializer,
+                    ILogger<RedisMessagePublisher> logger,
+                    RedisConnectionOptions options)
+                {
+                    _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+                    _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+                    _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+                    _serviceName = options?.ServiceName ?? "Unknown";
+                }
+
+                /// <inheritdoc/>
+                public async Task<long> PublishAsync<T>(string channel, T message, CancellationToken cancellationToken = default) where T : IMessage
+                {
+                    var envelope = MessageEnvelope<T>.Create(message, _serviceName);
+                    return await PublishEnvelopeAsync(channel, envelope, cancellationToken);
+                }
+
+                /// <inheritdoc/>
+                public async Task<long> PublishEnvelopeAsync<T>(string channel, MessageEnvelope<T> envelope, CancellationToken cancellationToken = default) where T : IMessage
+                {
+                    _logger.LogDebug("Publishing message {MessageType} to channel {Channel}", envelope.Header.MessageType, channel);
+
+                    var data = _serializer.Serialize(envelope);
+                    var subscriber = _redis.GetSubscriber();
+                    var result = await subscriber.PublishAsync(RedisChannel.Literal(channel), data);
+
+                    _logger.LogDebug("Message {MessageId} published to {SubscriberCount} subscribers", envelope.Header.MessageId, result);
+
+                    return result;
+                }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateIMessageSubscriberFile(string @namespace, string directory)
+    {
+        return new FileModel("IMessageSubscriber", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using {{@namespace}}.Messages;
+
+            namespace {{@namespace}}.PubSub;
+
+            /// <summary>
+            /// Interface for subscribing to messages from Redis pub/sub.
+            /// </summary>
+            public interface IMessageSubscriber
+            {
+                /// <summary>
+                /// Subscribes to messages on the specified channel.
+                /// </summary>
+                /// <typeparam name="T">The type of the message payload.</typeparam>
+                /// <param name="channel">The channel to subscribe to.</param>
+                /// <param name="handler">The handler to invoke when a message is received.</param>
+                /// <param name="cancellationToken">The cancellation token.</param>
+                /// <returns>A task that represents the asynchronous operation.</returns>
+                Task SubscribeAsync<T>(string channel, Func<MessageEnvelope<T>, Task> handler, CancellationToken cancellationToken = default) where T : IMessage;
+
+                /// <summary>
+                /// Unsubscribes from the specified channel.
+                /// </summary>
+                /// <param name="channel">The channel to unsubscribe from.</param>
+                /// <param name="cancellationToken">The cancellation token.</param>
+                /// <returns>A task that represents the asynchronous operation.</returns>
+                Task UnsubscribeAsync(string channel, CancellationToken cancellationToken = default);
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateRedisMessageSubscriberFile(string @namespace, string directory)
+    {
+        return new FileModel("RedisMessageSubscriber", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using Microsoft.Extensions.Logging;
+            using StackExchange.Redis;
+            using {{@namespace}}.Messages;
+            using {{@namespace}}.Services;
+
+            namespace {{@namespace}}.PubSub;
+
+            /// <summary>
+            /// Redis-based message subscriber implementation.
+            /// </summary>
+            public sealed class RedisMessageSubscriber : IMessageSubscriber, IAsyncDisposable
+            {
+                private readonly IConnectionMultiplexer _redis;
+                private readonly IMessageSerializer _serializer;
+                private readonly ILogger<RedisMessageSubscriber> _logger;
+                private readonly Dictionary<string, ChannelMessageQueue> _subscriptions = new();
+                private readonly SemaphoreSlim _lock = new(1, 1);
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="RedisMessageSubscriber"/> class.
+                /// </summary>
+                /// <param name="redis">The Redis connection multiplexer.</param>
+                /// <param name="serializer">The message serializer.</param>
+                /// <param name="logger">The logger.</param>
+                public RedisMessageSubscriber(
+                    IConnectionMultiplexer redis,
+                    IMessageSerializer serializer,
+                    ILogger<RedisMessageSubscriber> logger)
+                {
+                    _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+                    _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+                    _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+                }
+
+                /// <inheritdoc/>
+                public async Task SubscribeAsync<T>(string channel, Func<MessageEnvelope<T>, Task> handler, CancellationToken cancellationToken = default) where T : IMessage
+                {
+                    await _lock.WaitAsync(cancellationToken);
+                    try
+                    {
+                        _logger.LogInformation("Subscribing to channel {Channel} for message type {MessageType}", channel, typeof(T).Name);
+
+                        var subscriber = _redis.GetSubscriber();
+                        var queue = await subscriber.SubscribeAsync(RedisChannel.Literal(channel));
+
+                        _subscriptions[channel] = queue;
+
+                        _ = Task.Run(async () =>
+                        {
+                            await foreach (var message in queue)
+                            {
+                                try
+                                {
+                                    if (message.Message.HasValue)
+                                    {
+                                        var envelope = _serializer.Deserialize<T>((byte[])message.Message!);
+                                        if (envelope != null)
+                                        {
+                                            await handler(envelope);
+                                        }
+                                    }
+                                }
+                                catch (Exception ex)
+                                {
+                                    _logger.LogError(ex, "Error processing message on channel {Channel}", channel);
+                                }
+                            }
+                        }, cancellationToken);
+                    }
+                    finally
+                    {
+                        _lock.Release();
+                    }
+                }
+
+                /// <inheritdoc/>
+                public async Task UnsubscribeAsync(string channel, CancellationToken cancellationToken = default)
+                {
+                    await _lock.WaitAsync(cancellationToken);
+                    try
+                    {
+                        if (_subscriptions.TryGetValue(channel, out var queue))
+                        {
+                            await queue.UnsubscribeAsync();
+                            _subscriptions.Remove(channel);
+                            _logger.LogInformation("Unsubscribed from channel {Channel}", channel);
+                        }
+                    }
+                    finally
+                    {
+                        _lock.Release();
+                    }
+                }
+
+                /// <inheritdoc/>
+                public async ValueTask DisposeAsync()
+                {
+                    foreach (var subscription in _subscriptions.Values)
+                    {
+                        await subscription.UnsubscribeAsync();
+                    }
+                    _subscriptions.Clear();
+                    _lock.Dispose();
+                }
+            }
+            """
+        };
+    }
+
+    private static FileModel CreateRedisConnectionOptionsFile(string @namespace, string directory)
+    {
+        return new FileModel("RedisConnectionOptions", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            namespace {{@namespace}}.PubSub;
+
+            /// <summary>
+            /// Configuration options for Redis connection.
+            /// </summary>
+            public class RedisConnectionOptions
+            {
+                /// <summary>
+                /// Gets or sets the Redis connection string.
+                /// </summary>
+                public string ConnectionString { get; set; } = "localhost:6379";
+
+                /// <summary>
+                /// Gets or sets the service name for message headers.
+                /// </summary>
+                public string ServiceName { get; set; } = "Unknown";
+            }
+            """
+        };
+    }
+
+    #endregion
+
+    #region ConfigureServices
+
+    private static FileModel CreateConfigureServicesFile(string @namespace, string directory, bool includeRedisPubSub)
+    {
+        var redisPubSubRegistrations = includeRedisPubSub
+            ? """
+
+                /// <summary>
+                /// Adds Redis pub/sub messaging services to the service collection.
+                /// </summary>
+                /// <param name="services">The service collection.</param>
+                /// <param name="configure">Action to configure Redis connection options.</param>
+                /// <returns>The service collection for chaining.</returns>
+                public static IServiceCollection AddMessagingWithRedis(
+                    this IServiceCollection services,
+                    Action<RedisConnectionOptions>? configure = null)
+                {
+                    services.AddMessagingServices();
+
+                    var options = new RedisConnectionOptions();
+                    configure?.Invoke(options);
+
+                    services.AddSingleton(options);
+                    services.AddSingleton<IConnectionMultiplexer>(sp =>
+                        ConnectionMultiplexer.Connect(options.ConnectionString));
+                    services.AddSingleton<IMessagePublisher, RedisMessagePublisher>();
+                    services.AddSingleton<IMessageSubscriber, RedisMessageSubscriber>();
+
+                    return services;
+                }
+            """
+            : "";
+
+        var additionalUsings = includeRedisPubSub
+            ? $"""
+            using StackExchange.Redis;
+            using {@namespace}.PubSub;
+            """
+            : "";
+
+        return new FileModel("ConfigureServices", directory, CSharp)
+        {
+            Body = $$"""
+            // Copyright (c) Quinntyne Brown. All Rights Reserved.
+            // Licensed under the MIT License. See License.txt in the project root for license information.
+
+            using {{@namespace}}.Services;
+            {{additionalUsings}}
+
+            namespace Microsoft.Extensions.DependencyInjection;
+
+            /// <summary>
+            /// Extension methods for configuring messaging services.
+            /// </summary>
+            public static class ConfigureServices
+            {
+                /// <summary>
+                /// Adds messaging services to the service collection.
+                /// </summary>
+                /// <param name="services">The service collection.</param>
+                /// <returns>The service collection for chaining.</returns>
+                public static IServiceCollection AddMessagingServices(this IServiceCollection services)
+                {
+                    services.AddSingleton<IMessageTypeRegistry, MessageTypeRegistry>();
+                    services.AddSingleton<IMessageSerializer, MessagePackMessageSerializer>();
+                    return services;
+                }
+            {{redisPubSubRegistrations}}}
+            """
+        };
+    }
+
+    #endregion
+}

--- a/src/Endpoint.Engineering/Messaging/Artifacts/MessagingProjectModel.cs
+++ b/src/Endpoint.Engineering/Messaging/Artifacts/MessagingProjectModel.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.DotNet.Artifacts.Projects;
+using Endpoint.DotNet.Artifacts.Projects.Enums;
+using Endpoint.Engineering.Messaging.Models;
+
+namespace Endpoint.Engineering.Messaging.Artifacts;
+
+/// <summary>
+/// Represents a messaging project model with MessagePack and Redis support.
+/// </summary>
+public class MessagingProjectModel : ProjectModel
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagingProjectModel"/> class.
+    /// </summary>
+    public MessagingProjectModel()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagingProjectModel"/> class.
+    /// </summary>
+    /// <param name="projectName">The name of the project.</param>
+    /// <param name="parentDirectory">The parent directory for the project.</param>
+    /// <param name="includeRedisPubSub">Whether to include Redis pub/sub support.</param>
+    public MessagingProjectModel(string projectName, string parentDirectory, bool includeRedisPubSub = true)
+        : base(DotNetProjectType.ClassLib, $"{projectName}.Messaging", parentDirectory)
+    {
+        ProjectName = projectName;
+        IncludeRedisPubSub = includeRedisPubSub;
+
+        // Add MessagePack package
+        Packages.Add(new PackageModel("MessagePack", "2.6.100-alpha"));
+
+        // Add Redis packages if enabled
+        if (includeRedisPubSub)
+        {
+            Packages.Add(new PackageModel("StackExchange.Redis", "2.8.16"));
+        }
+
+        // Add DI package for ConfigureServices
+        Packages.Add(new PackageModel("Microsoft.Extensions.DependencyInjection.Abstractions", "9.0.0"));
+        Packages.Add(new PackageModel("Microsoft.Extensions.Logging.Abstractions", "9.0.0"));
+    }
+
+    /// <summary>
+    /// Gets or sets the project name (without .Messaging suffix).
+    /// </summary>
+    public string ProjectName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether to use LZ4 compression with MessagePack.
+    /// </summary>
+    public bool UseLz4Compression { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to include Redis pub/sub support.
+    /// </summary>
+    public bool IncludeRedisPubSub { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the message definitions for this project.
+    /// </summary>
+    public List<MessageDefinition> Messages { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the channel definitions for this project.
+    /// </summary>
+    public List<ChannelDefinition>? Channels { get; set; }
+}

--- a/src/Endpoint.Engineering/Messaging/Artifacts/Strategies/MessagingProjectArtifactGenerationStrategy.cs
+++ b/src/Endpoint.Engineering/Messaging/Artifacts/Strategies/MessagingProjectArtifactGenerationStrategy.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Artifacts;
+using Endpoint.Artifacts.Abstractions;
+using Endpoint.DotNet.Artifacts.Projects.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.Messaging.Artifacts.Strategies;
+
+/// <summary>
+/// Generation strategy for messaging projects.
+/// </summary>
+public class MessagingProjectArtifactGenerationStrategy : IArtifactGenerationStrategy<MessagingProjectModel>
+{
+    private readonly ILogger<MessagingProjectArtifactGenerationStrategy> _logger;
+    private readonly IProjectService _projectService;
+    private readonly IArtifactGenerator _artifactGenerator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessagingProjectArtifactGenerationStrategy"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="projectService">The project service.</param>
+    /// <param name="artifactGenerator">The artifact generator.</param>
+    public MessagingProjectArtifactGenerationStrategy(
+        ILogger<MessagingProjectArtifactGenerationStrategy> logger,
+        IProjectService projectService,
+        IArtifactGenerator artifactGenerator)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(projectService);
+        ArgumentNullException.ThrowIfNull(artifactGenerator);
+
+        _logger = logger;
+        _projectService = projectService;
+        _artifactGenerator = artifactGenerator;
+    }
+
+    /// <inheritdoc/>
+    public int GetPriority() => 1;
+
+    /// <inheritdoc/>
+    public async Task GenerateAsync(MessagingProjectModel model)
+    {
+        _logger.LogInformation("Generating messaging project: {ProjectName}", model.Name);
+
+        // Create the project using the project service
+        await _projectService.AddProjectAsync(model);
+
+        // Generate all files for the project
+        foreach (var file in model.Files)
+        {
+            await _artifactGenerator.GenerateAsync(file);
+        }
+
+        // Add project to solution
+        _projectService.AddToSolution(model);
+
+        _logger.LogInformation("Messaging project generated successfully: {ProjectName} with {MessageCount} messages",
+            model.Name, model.Messages.Count);
+    }
+}

--- a/src/Endpoint.Engineering/Messaging/ConfigureServices.cs
+++ b/src/Endpoint.Engineering/Messaging/ConfigureServices.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint;
+using Endpoint.Engineering.Messaging.Artifacts;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for configuring Messaging project generator services.
+/// </summary>
+public static class MessagingConfigureServices
+{
+    /// <summary>
+    /// Adds Messaging project generator services to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddMessagingProjectGeneratorServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IMessagingArtifactFactory, MessagingArtifactFactory>();
+        services.AddArifactGenerator(typeof(MessagingProjectModel).Assembly);
+
+        return services;
+    }
+}

--- a/src/Endpoint.Engineering/Messaging/Models/MessageDefinition.cs
+++ b/src/Endpoint.Engineering/Messaging/Models/MessageDefinition.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Endpoint.Engineering.Messaging.Models;
+
+/// <summary>
+/// Represents a message definition following industry standards (CloudEvents/AsyncAPI inspired).
+/// </summary>
+public class MessageDefinition
+{
+    /// <summary>
+    /// Gets or sets the message name (used as the class name).
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the message type discriminator for serialization.
+    /// Follows CloudEvents type format: {domain}.{version}.{eventType}
+    /// Example: "com.example.order.v1.OrderCreated"
+    /// </summary>
+    [JsonPropertyName("messageType")]
+    public string? MessageType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message kind (Event, Command, Query).
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public MessageKind Kind { get; set; } = MessageKind.Event;
+
+    /// <summary>
+    /// Gets or sets the description for XML documentation.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the schema version for message evolution.
+    /// </summary>
+    [JsonPropertyName("schemaVersion")]
+    public int SchemaVersion { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the properties of the message.
+    /// </summary>
+    [JsonPropertyName("properties")]
+    public List<MessagePropertyDefinition> Properties { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the aggregate type for domain events.
+    /// </summary>
+    [JsonPropertyName("aggregateType")]
+    public string? AggregateType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the channel/topic where this message is published.
+    /// </summary>
+    [JsonPropertyName("channel")]
+    public string? Channel { get; set; }
+
+    /// <summary>
+    /// Gets the computed message type using CloudEvents format.
+    /// </summary>
+    public string ComputedMessageType => MessageType ?? $"{Name}";
+}
+
+/// <summary>
+/// Defines the kind of message.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MessageKind
+{
+    /// <summary>
+    /// An event that represents something that happened.
+    /// </summary>
+    Event,
+
+    /// <summary>
+    /// A command that represents an intent to do something.
+    /// </summary>
+    Command,
+
+    /// <summary>
+    /// A query that represents a request for data.
+    /// </summary>
+    Query
+}

--- a/src/Endpoint.Engineering/Messaging/Models/MessagePropertyDefinition.cs
+++ b/src/Endpoint.Engineering/Messaging/Models/MessagePropertyDefinition.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Endpoint.Engineering.Messaging.Models;
+
+/// <summary>
+/// Represents a property definition for a message.
+/// </summary>
+public class MessagePropertyDefinition
+{
+    /// <summary>
+    /// Gets or sets the property name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the property type (e.g., "string", "int", "Guid", "DateTime", "decimal").
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "string";
+
+    /// <summary>
+    /// Gets or sets whether the property is required.
+    /// </summary>
+    [JsonPropertyName("required")]
+    public bool Required { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether the property is nullable.
+    /// </summary>
+    [JsonPropertyName("nullable")]
+    public bool Nullable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the property description for XML documentation.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default value for the property.
+    /// </summary>
+    [JsonPropertyName("defaultValue")]
+    public string? DefaultValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the property is a collection.
+    /// </summary>
+    [JsonPropertyName("isCollection")]
+    public bool IsCollection { get; set; }
+
+    /// <summary>
+    /// Gets or sets the collection type (e.g., "List", "IEnumerable", "Array").
+    /// </summary>
+    [JsonPropertyName("collectionType")]
+    public string CollectionType { get; set; } = "List";
+}

--- a/src/Endpoint.Engineering/Messaging/Models/MessagingProjectDefinition.cs
+++ b/src/Endpoint.Engineering/Messaging/Models/MessagingProjectDefinition.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Endpoint.Engineering.Messaging.Models;
+
+/// <summary>
+/// Represents the complete messaging project definition.
+/// This model follows AsyncAPI specification patterns for message-driven architectures.
+/// </summary>
+public class MessagingProjectDefinition
+{
+    /// <summary>
+    /// Gets or sets the schema version of this definition file.
+    /// </summary>
+    [JsonPropertyName("$schema")]
+    public string Schema { get; set; } = "https://endpoint.dev/schemas/messaging/v1.0.json";
+
+    /// <summary>
+    /// Gets or sets the project name (without .Messaging suffix).
+    /// </summary>
+    [JsonPropertyName("projectName")]
+    public string ProjectName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the root namespace for the messaging project.
+    /// </summary>
+    [JsonPropertyName("namespace")]
+    public string? Namespace { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description of the messaging project.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version of the messaging contract.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = "1.0.0";
+
+    /// <summary>
+    /// Gets or sets whether to use LZ4 compression with MessagePack.
+    /// </summary>
+    [JsonPropertyName("useLz4Compression")]
+    public bool UseLz4Compression { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to include Redis pub/sub support.
+    /// </summary>
+    [JsonPropertyName("includeRedisPubSub")]
+    public bool IncludeRedisPubSub { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the message definitions.
+    /// </summary>
+    [JsonPropertyName("messages")]
+    public List<MessageDefinition> Messages { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets channel definitions for pub/sub patterns.
+    /// </summary>
+    [JsonPropertyName("channels")]
+    public List<ChannelDefinition>? Channels { get; set; }
+
+    /// <summary>
+    /// Gets the computed namespace.
+    /// </summary>
+    public string ComputedNamespace => Namespace ?? $"{ProjectName}.Messaging";
+}
+
+/// <summary>
+/// Represents a channel/topic definition for pub/sub messaging.
+/// </summary>
+public class ChannelDefinition
+{
+    /// <summary>
+    /// Gets or sets the channel name (e.g., "orders", "notifications").
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the description of the channel.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message types that are published to this channel.
+    /// </summary>
+    [JsonPropertyName("publishedMessages")]
+    public List<string>? PublishedMessages { get; set; }
+
+    /// <summary>
+    /// Gets or sets the message types that are subscribed from this channel.
+    /// </summary>
+    [JsonPropertyName("subscribedMessages")]
+    public List<string>? SubscribedMessages { get; set; }
+}


### PR DESCRIPTION
This adds a new Messaging folder in Endpoint.Engineering with:
- Models for message definitions (MessageDefinition, MessagePropertyDefinition, MessagingProjectDefinition)
- IMessagingArtifactFactory interface and MessagingArtifactFactory implementation
- MessagingProjectModel that includes MessagePack and StackExchange.Redis packages
- Generation strategy for messaging projects
- CLI command (messaging-project-add) that accepts JSON definition files

Features:
- Accept array of message definitions from JSON files
- Generate message classes with MessagePack attributes
- Support for Events, Commands, and Queries
- Include Redis pub/sub publisher/subscriber infrastructure
- Industry-standard JSON schema inspired by CloudEvents/AsyncAPI
- LZ4 compression support for MessagePack serialization

Also includes MessagingProjectDemo playground project with sample JSON definitions.