### PR TITLE
Update Efficiency option to integer range 0-100

### DIFF
--- a/src/Endpoint.Engineering/AI/Services/CodeParser.cs
+++ b/src/Endpoint.Engineering/AI/Services/CodeParser.cs
@@ -209,7 +209,7 @@ public partial class CodeParser : ICodeParser
             try
             {
                 var content = await File.ReadAllTextAsync(file, cancellationToken);
-                var relativePath = Path.GetRelativePath(directory, file);
+                var relativePath = Path.GetRelativePath(directory, file).Replace('\\', '/');
                 var extension = Path.GetExtension(file).ToLowerInvariant();
 
                 var isTestFile = IsTestFileByContent(content);
@@ -231,6 +231,12 @@ public partial class CodeParser : ICodeParser
                 includedFiles++;
                 var fileSummary = ParseFile(content, relativePath, extension);
                 summary.Files.Add(fileSummary);
+
+                // Store raw content when efficiency is 0 (verbatim mode)
+                if (options.Efficiency == 0)
+                {
+                    summary.RawContents[relativePath] = content;
+                }
             }
             catch (Exception ex)
             {

--- a/src/Endpoint.Engineering/AI/Services/ICodeParser.cs
+++ b/src/Endpoint.Engineering/AI/Services/ICodeParser.cs
@@ -4,44 +4,17 @@
 namespace Endpoint.Engineering.AI.Services;
 
 /// <summary>
-/// Specifies the level of token efficiency for code parsing output.
-/// </summary>
-public enum CodeParseEfficiency
-{
-    /// <summary>
-    /// Low efficiency - maximum detail. Include all members, full type info, all imports.
-    /// Best for small codebases (under 100 files).
-    /// </summary>
-    Low = 1,
-
-    /// <summary>
-    /// Medium efficiency - balanced detail. Include types with limited members, simplified imports.
-    /// Best for medium codebases (100-500 files).
-    /// </summary>
-    Medium = 2,
-
-    /// <summary>
-    /// High efficiency - minimal tokens. Only type names, counts, and structure overview.
-    /// Best for large codebases (500+ files).
-    /// </summary>
-    High = 3,
-
-    /// <summary>
-    /// Maximum efficiency - ultra-compact. Only file counts and top-level structure.
-    /// Best for very large codebases or initial exploration.
-    /// </summary>
-    Max = 4
-}
-
-/// <summary>
 /// Options for code parsing.
 /// </summary>
 public class CodeParseOptions
 {
     /// <summary>
-    /// The level of token efficiency for the output.
+    /// The level of token efficiency for the output (0-100).
+    /// 0 = verbatim (parse all code with full content)
+    /// 100 = minimal (most compact summary)
+    /// Values in between produce progressively smaller output.
     /// </summary>
-    public CodeParseEfficiency Efficiency { get; set; } = CodeParseEfficiency.Medium;
+    public int Efficiency { get; set; } = 50;
 
     /// <summary>
     /// When true, ignores test files and test projects.
@@ -61,8 +34,8 @@ public class CodeParseOptions
     /// <summary>
     /// Creates options with specified efficiency.
     /// </summary>
-    public static CodeParseOptions WithEfficiency(CodeParseEfficiency efficiency) =>
-        new() { Efficiency = efficiency };
+    public static CodeParseOptions WithEfficiency(int efficiency) =>
+        new() { Efficiency = Math.Clamp(efficiency, 0, 100) };
 }
 
 /// <summary>
@@ -104,31 +77,110 @@ public class CodeSummary
     public int TotalFiles { get; set; }
 
     /// <summary>
-    /// The efficiency level used during parsing.
+    /// The efficiency level used during parsing (0-100).
+    /// 0 = verbatim (full code content)
+    /// 100 = minimal (most compact summary)
     /// </summary>
-    public CodeParseEfficiency Efficiency { get; set; } = CodeParseEfficiency.Medium;
+    public int Efficiency { get; set; } = 50;
+
+    /// <summary>
+    /// Raw file contents indexed by relative path (populated when Efficiency is low).
+    /// </summary>
+    public Dictionary<string, string> RawContents { get; set; } = [];
 
     /// <summary>
     /// Generates a token-efficient string representation for LLM consumption.
+    /// The output size decreases as efficiency increases from 0 to 100.
     /// </summary>
     public string ToLlmString()
     {
-        return Efficiency switch
-        {
-            CodeParseEfficiency.Low => ToLlmStringLow(),
-            CodeParseEfficiency.Medium => ToLlmStringMedium(),
-            CodeParseEfficiency.High => ToLlmStringHigh(),
-            CodeParseEfficiency.Max => ToLlmStringMax(),
-            _ => ToLlmStringMedium()
-        };
+        // Efficiency ranges:
+        // 0: Verbatim - full file contents
+        // 1-25: Full detail - all members, all imports, complete structure
+        // 26-50: Balanced - limited members, simplified imports
+        // 51-75: Compact - type summaries, grouped by directory
+        // 76-100: Minimal - file counts, type counts, directory overview
+
+        if (Efficiency == 0)
+            return ToLlmStringVerbatim();
+
+        if (Efficiency <= 25)
+            return ToLlmStringFullDetail();
+
+        if (Efficiency <= 50)
+            return ToLlmStringBalanced();
+
+        if (Efficiency <= 75)
+            return ToLlmStringCompact();
+
+        return ToLlmStringMinimal();
     }
 
-    private string ToLlmStringLow()
+    private string ToLlmStringVerbatim()
     {
         var sb = new System.Text.StringBuilder();
         sb.AppendLine($"# Codebase: {Path.GetFileName(RootDirectory)}");
         sb.AppendLine($"Files: {TotalFiles}");
         sb.AppendLine();
+
+        foreach (var file in Files)
+        {
+            sb.AppendLine($"## {file.RelativePath}");
+
+            // Include raw content if available
+            if (RawContents.TryGetValue(file.RelativePath, out var content))
+            {
+                sb.AppendLine("```");
+                sb.AppendLine(content);
+                sb.AppendLine("```");
+            }
+            else
+            {
+                // Fallback to structured output
+                if (file.Namespaces.Count > 0)
+                    sb.AppendLine($"namespace: {string.Join(", ", file.Namespaces)}");
+
+                if (file.Imports.Count > 0)
+                    sb.AppendLine($"imports: {string.Join(", ", file.Imports)}");
+
+                foreach (var type in file.Types)
+                {
+                    var modifiers = type.Modifiers.Count > 0 ? $"{string.Join(" ", type.Modifiers)} " : "";
+                    var baseTypes = type.BaseTypes.Count > 0 ? $" : {string.Join(", ", type.BaseTypes)}" : "";
+                    sb.AppendLine($"  {modifiers}{type.Kind} {type.Name}{baseTypes}");
+
+                    foreach (var member in type.Members)
+                    {
+                        sb.AppendLine($"    {member}");
+                    }
+                }
+
+                if (file.Functions.Count > 0)
+                {
+                    sb.AppendLine("  Functions:");
+                    foreach (var func in file.Functions)
+                    {
+                        sb.AppendLine($"    {func}");
+                    }
+                }
+            }
+
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    private string ToLlmStringFullDetail()
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"# Codebase: {Path.GetFileName(RootDirectory)}");
+        sb.AppendLine($"Files: {TotalFiles}");
+        sb.AppendLine();
+
+        // Calculate how many members to show based on efficiency (1-25 maps to showing all to ~75%)
+        var memberRatio = 1.0 - ((Efficiency - 1) / 24.0 * 0.25);
+        var importRatio = 1.0 - ((Efficiency - 1) / 24.0 * 0.25);
 
         foreach (var file in Files)
         {
@@ -138,7 +190,12 @@ public class CodeSummary
                 sb.AppendLine($"namespace: {string.Join(", ", file.Namespaces)}");
 
             if (file.Imports.Count > 0)
-                sb.AppendLine($"imports: {string.Join(", ", file.Imports)}");
+            {
+                var importsToShow = (int)Math.Ceiling(file.Imports.Count * importRatio);
+                var imports = file.Imports.Take(importsToShow);
+                var remaining = file.Imports.Count - importsToShow;
+                sb.AppendLine($"imports: {string.Join(", ", imports)}{(remaining > 0 ? $" (+{remaining})" : "")}");
+            }
 
             foreach (var type in file.Types)
             {
@@ -146,18 +203,32 @@ public class CodeSummary
                 var baseTypes = type.BaseTypes.Count > 0 ? $" : {string.Join(", ", type.BaseTypes)}" : "";
                 sb.AppendLine($"  {modifiers}{type.Kind} {type.Name}{baseTypes}");
 
-                foreach (var member in type.Members)
+                var membersToShow = (int)Math.Ceiling(type.Members.Count * memberRatio);
+                var members = type.Members.Take(membersToShow);
+                foreach (var member in members)
                 {
                     sb.AppendLine($"    {member}");
+                }
+                var remainingMembers = type.Members.Count - membersToShow;
+                if (remainingMembers > 0)
+                {
+                    sb.AppendLine($"    ...+{remainingMembers} more");
                 }
             }
 
             if (file.Functions.Count > 0)
             {
                 sb.AppendLine("  Functions:");
-                foreach (var func in file.Functions)
+                var funcsToShow = (int)Math.Ceiling(file.Functions.Count * memberRatio);
+                var funcs = file.Functions.Take(funcsToShow);
+                foreach (var func in funcs)
                 {
                     sb.AppendLine($"    {func}");
+                }
+                var remainingFuncs = file.Functions.Count - funcsToShow;
+                if (remainingFuncs > 0)
+                {
+                    sb.AppendLine($"    ...+{remainingFuncs} more");
                 }
             }
 
@@ -167,12 +238,18 @@ public class CodeSummary
         return sb.ToString();
     }
 
-    private string ToLlmStringMedium()
+    private string ToLlmStringBalanced()
     {
         var sb = new System.Text.StringBuilder();
         sb.AppendLine($"# Codebase: {Path.GetFileName(RootDirectory)}");
         sb.AppendLine($"Files: {TotalFiles}");
         sb.AppendLine();
+
+        // Calculate limits based on efficiency (26-50 maps to showing less progressively)
+        var normalizedEfficiency = (Efficiency - 26) / 24.0; // 0 to 1
+        var maxMembers = (int)Math.Max(1, 10 - normalizedEfficiency * 8); // 10 down to 2
+        var maxImports = (int)Math.Max(1, 15 - normalizedEfficiency * 12); // 15 down to 3
+        var maxFunctions = (int)Math.Max(1, 8 - normalizedEfficiency * 6); // 8 down to 2
 
         foreach (var file in Files)
         {
@@ -182,7 +259,11 @@ public class CodeSummary
                 sb.AppendLine($"ns: {string.Join(", ", file.Namespaces)}");
 
             if (file.Imports.Count > 0)
-                sb.AppendLine($"uses: {string.Join(", ", file.Imports.Take(10))}{(file.Imports.Count > 10 ? "..." : "")}");
+            {
+                var imports = file.Imports.Take(maxImports);
+                var remaining = file.Imports.Count - maxImports;
+                sb.AppendLine($"uses: {string.Join(", ", imports)}{(remaining > 0 ? "..." : "")}");
+            }
 
             foreach (var type in file.Types)
             {
@@ -190,28 +271,27 @@ public class CodeSummary
                 var baseTypes = type.BaseTypes.Count > 0 ? $" : {string.Join(", ", type.BaseTypes)}" : "";
                 sb.AppendLine($"  {modifiers}{type.Kind} {type.Name}{baseTypes}");
 
-                // Limit members in medium efficiency
-                var membersToShow = type.Members.Take(5).ToList();
+                var membersToShow = type.Members.Take(maxMembers).ToList();
                 foreach (var member in membersToShow)
                 {
                     sb.AppendLine($"    {member}");
                 }
-                if (type.Members.Count > 5)
+                if (type.Members.Count > maxMembers)
                 {
-                    sb.AppendLine($"    ...+{type.Members.Count - 5} more");
+                    sb.AppendLine($"    ...+{type.Members.Count - maxMembers} more");
                 }
             }
 
             if (file.Functions.Count > 0)
             {
-                var funcsToShow = file.Functions.Take(5).ToList();
+                var funcsToShow = file.Functions.Take(maxFunctions).ToList();
                 foreach (var func in funcsToShow)
                 {
                     sb.AppendLine($"  fn: {func}");
                 }
-                if (file.Functions.Count > 5)
+                if (file.Functions.Count > maxFunctions)
                 {
-                    sb.AppendLine($"  ...+{file.Functions.Count - 5} more");
+                    sb.AppendLine($"  ...+{file.Functions.Count - maxFunctions} more");
                 }
             }
 
@@ -221,11 +301,16 @@ public class CodeSummary
         return sb.ToString();
     }
 
-    private string ToLlmStringHigh()
+    private string ToLlmStringCompact()
     {
         var sb = new System.Text.StringBuilder();
         sb.AppendLine($"# {Path.GetFileName(RootDirectory)} ({TotalFiles} files)");
         sb.AppendLine();
+
+        // Calculate how much detail to show (51-75 maps to progressively less)
+        var normalizedEfficiency = (Efficiency - 51) / 24.0; // 0 to 1
+        var showTypes = normalizedEfficiency < 0.5; // Show types only in first half
+        var maxTypesPerFile = (int)Math.Max(1, 5 - normalizedEfficiency * 4); // 5 down to 1
 
         // Group files by directory
         var filesByDir = Files
@@ -240,24 +325,37 @@ public class CodeSummary
             foreach (var file in dirGroup)
             {
                 var fileName = Path.GetFileName(file.RelativePath);
-                var typeCount = file.Types.Count;
-                var funcCount = file.Functions.Count;
 
-                var typeSummary = typeCount > 0
-                    ? $"[{string.Join(",", file.Types.Select(t => $"{t.Kind[0]}:{t.Name}"))}]"
-                    : "";
-
-                sb.AppendLine($"  {fileName} {typeSummary}");
+                if (showTypes && file.Types.Count > 0)
+                {
+                    var types = file.Types.Take(maxTypesPerFile);
+                    var typeSummary = $"[{string.Join(",", types.Select(t => $"{t.Kind[0]}:{t.Name}"))}]";
+                    var remaining = file.Types.Count - maxTypesPerFile;
+                    sb.AppendLine($"  {fileName} {typeSummary}{(remaining > 0 ? $"+{remaining}" : "")}");
+                }
+                else
+                {
+                    var counts = new List<string>();
+                    if (file.Types.Count > 0) counts.Add($"{file.Types.Count}t");
+                    if (file.Functions.Count > 0) counts.Add($"{file.Functions.Count}f");
+                    var summary = counts.Count > 0 ? $"({string.Join(",", counts)})" : "";
+                    sb.AppendLine($"  {fileName} {summary}");
+                }
             }
         }
 
         return sb.ToString();
     }
 
-    private string ToLlmStringMax()
+    private string ToLlmStringMinimal()
     {
         var sb = new System.Text.StringBuilder();
         sb.AppendLine($"# {Path.GetFileName(RootDirectory)}");
+
+        // Calculate how minimal to be (76-100 maps to progressively less)
+        var normalizedEfficiency = (Efficiency - 76) / 24.0; // 0 to 1
+        var showTypeBreakdown = normalizedEfficiency < 0.5;
+        var maxDirs = (int)Math.Max(3, 10 - normalizedEfficiency * 7); // 10 down to 3
 
         // Count by extension
         var byExtension = Files
@@ -269,21 +367,27 @@ public class CodeSummary
 
         // Count types
         var totalTypes = Files.Sum(f => f.Types.Count);
-        var typesByKind = Files
-            .SelectMany(f => f.Types)
-            .GroupBy(t => t.Kind)
-            .OrderByDescending(g => g.Count())
-            .Select(g => $"{g.Key}:{g.Count()}");
+        if (totalTypes > 0 && showTypeBreakdown)
+        {
+            var typesByKind = Files
+                .SelectMany(f => f.Types)
+                .GroupBy(t => t.Kind)
+                .OrderByDescending(g => g.Count())
+                .Select(g => $"{g.Key}:{g.Count()}");
 
-        if (totalTypes > 0)
             sb.AppendLine($"Types: {totalTypes} ({string.Join(" ", typesByKind)})");
+        }
+        else if (totalTypes > 0)
+        {
+            sb.AppendLine($"Types: {totalTypes}");
+        }
 
         // List directories with file counts
         var dirs = Files
             .Select(f => Path.GetDirectoryName(f.RelativePath) ?? "(root)")
             .GroupBy(d => d)
             .OrderByDescending(g => g.Count())
-            .Take(10)
+            .Take(maxDirs)
             .Select(g => $"{g.Key}({g.Count()})");
 
         sb.AppendLine($"Dirs: {string.Join(" ", dirs)}");


### PR DESCRIPTION
- Change Efficiency from enum (Low/Medium/High/Max) to integer (0-100)
- 0 = verbatim mode (full code content included)
- 100 = minimal mode (most compact summary)
- Values in between produce progressively smaller output
- Add RawContents dictionary to store file content for verbatim mode
- Copy result to clipboard after code parse completion
- Update demo app to showcase efficiency level comparison