### PR TITLE
Add prune-by-type command to CLI

### DIFF
--- a/src/Endpoint.Engineering.Cli/Commands/PruneByType.cs
+++ b/src/Endpoint.Engineering.Cli/Commands/PruneByType.cs
@@ -1,0 +1,231 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CommandLine;
+using Endpoint.Engineering.SolutionPruning;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.Cli.Commands;
+
+[Verb("prune-by-type", HelpText = "Prune a .NET solution to only include a specific type and its dependencies/references.")]
+public class PruneByTypeRequest : IRequest
+{
+    [Option('t', "type", Required = true,
+        HelpText = "The fully qualified name of the .NET type to prune around (e.g., 'MyNamespace.MyClass').")]
+    public string TypeName { get; set; } = string.Empty;
+
+    [Option('s', "solution", Required = true,
+        HelpText = "Path to the .NET solution file (.sln).")]
+    public string SolutionPath { get; set; } = string.Empty;
+
+    [Option('o', "output", Required = false,
+        HelpText = "Output directory for the pruned solution. Defaults to '<SolutionName>.Pruned' in the solution directory.")]
+    public string? OutputDirectory { get; set; }
+
+    [Option('v', "verbose", Required = false, Default = false,
+        HelpText = "Show verbose output including all included types.")]
+    public bool Verbose { get; set; }
+
+    [Option("no-color", Required = false, Default = false,
+        HelpText = "Disable colorized output.")]
+    public bool NoColor { get; set; }
+}
+
+public class PruneByTypeRequestHandler : IRequestHandler<PruneByTypeRequest>
+{
+    private readonly ILogger<PruneByTypeRequestHandler> _logger;
+    private readonly ISolutionPruneService _solutionPruneService;
+
+    public PruneByTypeRequestHandler(
+        ILogger<PruneByTypeRequestHandler> logger,
+        ISolutionPruneService solutionPruneService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _solutionPruneService = solutionPruneService ?? throw new ArgumentNullException(nameof(solutionPruneService));
+    }
+
+    public async Task Handle(PruneByTypeRequest request, CancellationToken cancellationToken)
+    {
+        WriteHeader(request.NoColor);
+
+        try
+        {
+            // Validate solution path
+            var solutionPath = Path.GetFullPath(request.SolutionPath);
+            if (!File.Exists(solutionPath))
+            {
+                WriteError($"Solution file not found: {solutionPath}", request.NoColor);
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            WriteInfo($"Solution: {solutionPath}", request.NoColor);
+            WriteInfo($"Target Type: {request.TypeName}", request.NoColor);
+            Console.WriteLine();
+
+            WriteProgress("Loading solution and analyzing types...", request.NoColor);
+
+            var result = await _solutionPruneService.PruneAsync(
+                solutionPath,
+                request.TypeName,
+                request.OutputDirectory,
+                cancellationToken);
+
+            Console.WriteLine();
+
+            if (result.Success)
+            {
+                DisplayResults(result, request.Verbose, request.NoColor);
+            }
+            else
+            {
+                WriteError($"Error: {result.ErrorMessage}", request.NoColor);
+                Environment.ExitCode = 1;
+            }
+        }
+        catch (Exception ex)
+        {
+            WriteError($"Unexpected error: {ex.Message}", request.NoColor);
+            _logger.LogError(ex, "Error during prune-by-type operation");
+            Environment.ExitCode = 1;
+        }
+    }
+
+    private static void WriteHeader(bool noColor)
+    {
+        Console.WriteLine();
+        if (!noColor)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+        }
+        Console.WriteLine("=== Prune By Type ===");
+        if (!noColor)
+        {
+            Console.ResetColor();
+        }
+        Console.WriteLine();
+    }
+
+    private static void WriteInfo(string message, bool noColor)
+    {
+        Console.WriteLine(message);
+    }
+
+    private static void WriteProgress(string message, bool noColor)
+    {
+        if (!noColor)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+        }
+        Console.WriteLine(message);
+        if (!noColor)
+        {
+            Console.ResetColor();
+        }
+    }
+
+    private static void WriteError(string message, bool noColor)
+    {
+        if (!noColor)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+        }
+        Console.WriteLine(message);
+        if (!noColor)
+        {
+            Console.ResetColor();
+        }
+    }
+
+    private static void WriteSuccess(string message, bool noColor)
+    {
+        if (!noColor)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+        }
+        Console.WriteLine(message);
+        if (!noColor)
+        {
+            Console.ResetColor();
+        }
+    }
+
+    private static void DisplayResults(SolutionPruneResult result, bool verbose, bool noColor)
+    {
+        // Success message
+        WriteSuccess("Pruning completed successfully!", noColor);
+        Console.WriteLine();
+
+        // Summary
+        if (!noColor)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+        }
+        Console.WriteLine("=== Summary ===");
+        if (!noColor)
+        {
+            Console.ResetColor();
+        }
+        Console.WriteLine();
+
+        Console.WriteLine($"Target Type: {result.TargetTypeName}");
+        Console.WriteLine($"Output: {result.PrunedSolutionPath}");
+        Console.WriteLine();
+
+        Console.WriteLine($"Types included: {result.IncludedTypes.Count}");
+        Console.WriteLine($"  - Dependencies: {result.DependencyTypeCount}");
+        Console.WriteLine($"  - References: {result.DependentTypeCount}");
+        Console.WriteLine();
+
+        Console.WriteLine($"Projects included: {result.IncludedProjects.Count}");
+        foreach (var project in result.IncludedProjects)
+        {
+            Console.WriteLine($"  - {project}");
+        }
+        Console.WriteLine();
+
+        Console.WriteLine($"Files included: {result.IncludedFiles.Count}");
+
+        if (verbose)
+        {
+            Console.WriteLine();
+            if (!noColor)
+            {
+                Console.ForegroundColor = ConsoleColor.Cyan;
+            }
+            Console.WriteLine("=== Included Types ===");
+            if (!noColor)
+            {
+                Console.ResetColor();
+            }
+            Console.WriteLine();
+
+            foreach (var type in result.IncludedTypes)
+            {
+                Console.WriteLine($"  {type}");
+            }
+            Console.WriteLine();
+
+            if (!noColor)
+            {
+                Console.ForegroundColor = ConsoleColor.Cyan;
+            }
+            Console.WriteLine("=== Included Files ===");
+            if (!noColor)
+            {
+                Console.ResetColor();
+            }
+            Console.WriteLine();
+
+            foreach (var file in result.IncludedFiles)
+            {
+                Console.WriteLine($"  {file}");
+            }
+        }
+    }
+}

--- a/src/Endpoint.Engineering/ConfigureServices.cs
+++ b/src/Endpoint.Engineering/ConfigureServices.cs
@@ -37,6 +37,7 @@ using Endpoint.Engineering.Microservices.GitAnalysis;
 using Endpoint.Engineering.Microservices.RealtimeNotification;
 using Endpoint.Engineering.Messaging.Artifacts;
 using Endpoint.Engineering.StaticAnalysis.Angular;
+using Endpoint.Engineering.SolutionPruning;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -65,6 +66,9 @@ public static class ConfigureServices
         services.AddSingleton<IStaticAnalysisService, StaticAnalysisService>();
         // Register Code Review Service
         services.AddSingleton<ICodeReviewService, CodeReviewService>();
+
+        // Register Solution Prune Service
+        services.AddSingleton<ISolutionPruneService, SolutionPruneService>();
 
         // Register artifact factories for all microservices
         services.AddSingleton<IIdentityArtifactFactory, IdentityArtifactFactory>();

--- a/src/Endpoint.Engineering/SolutionPruning/ISolutionPruneService.cs
+++ b/src/Endpoint.Engineering/SolutionPruning/ISolutionPruneService.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Endpoint.Engineering.SolutionPruning;
+
+/// <summary>
+/// Service for pruning a .NET solution to only include a specified type and its dependencies/references.
+/// </summary>
+public interface ISolutionPruneService
+{
+    /// <summary>
+    /// Prunes a .NET solution to only include the specified type and its transitive dependencies and references.
+    /// </summary>
+    /// <param name="solutionPath">Path to the .NET solution file (.sln).</param>
+    /// <param name="fullyQualifiedTypeName">The fully qualified name of the type to prune around (e.g., "MyNamespace.MyClass").</param>
+    /// <param name="outputDirectory">Optional output directory for the pruned solution. If not specified, creates a subfolder in the solution directory.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The result of the pruning operation.</returns>
+    Task<SolutionPruneResult> PruneAsync(
+        string solutionPath,
+        string fullyQualifiedTypeName,
+        string? outputDirectory = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result of a solution pruning operation.
+/// </summary>
+public class SolutionPruneResult
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the operation was successful.
+    /// </summary>
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// Gets or sets the error message if the operation failed.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the pruned solution file.
+    /// </summary>
+    public string? PrunedSolutionPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fully qualified name of the target type.
+    /// </summary>
+    public string? TargetTypeName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of types included in the pruned solution.
+    /// </summary>
+    public List<string> IncludedTypes { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the list of files included in the pruned solution.
+    /// </summary>
+    public List<string> IncludedFiles { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the list of projects included in the pruned solution.
+    /// </summary>
+    public List<string> IncludedProjects { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the count of types that depend on the target type.
+    /// </summary>
+    public int DependentTypeCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the count of types that the target type depends on.
+    /// </summary>
+    public int DependencyTypeCount { get; set; }
+}

--- a/src/Endpoint.Engineering/SolutionPruning/SolutionPruneService.cs
+++ b/src/Endpoint.Engineering/SolutionPruning/SolutionPruneService.cs
@@ -1,0 +1,743 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.SolutionPruning;
+
+/// <summary>
+/// Service for pruning a .NET solution to only include a specified type and its dependencies/references.
+/// </summary>
+public class SolutionPruneService : ISolutionPruneService
+{
+    private readonly ILogger<SolutionPruneService> _logger;
+    private static bool _msBuildRegistered;
+    private static readonly object _registrationLock = new();
+
+    public SolutionPruneService(ILogger<SolutionPruneService> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        EnsureMSBuildRegistered();
+    }
+
+    private static void EnsureMSBuildRegistered()
+    {
+        lock (_registrationLock)
+        {
+            if (!_msBuildRegistered)
+            {
+                try
+                {
+                    MSBuildLocator.RegisterDefaults();
+                    _msBuildRegistered = true;
+                }
+                catch (InvalidOperationException)
+                {
+                    // Already registered
+                    _msBuildRegistered = true;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<SolutionPruneResult> PruneAsync(
+        string solutionPath,
+        string fullyQualifiedTypeName,
+        string? outputDirectory = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = new SolutionPruneResult
+        {
+            TargetTypeName = fullyQualifiedTypeName
+        };
+
+        try
+        {
+            // Validate inputs
+            if (!File.Exists(solutionPath))
+            {
+                result.ErrorMessage = $"Solution file not found: {solutionPath}";
+                return result;
+            }
+
+            if (string.IsNullOrWhiteSpace(fullyQualifiedTypeName))
+            {
+                result.ErrorMessage = "Fully qualified type name is required.";
+                return result;
+            }
+
+            _logger.LogInformation("Loading solution: {SolutionPath}", solutionPath);
+
+            // Load the solution
+            using var workspace = MSBuildWorkspace.Create();
+            workspace.WorkspaceFailed += (sender, args) =>
+            {
+                if (args.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
+                {
+                    _logger.LogWarning("Workspace warning: {Message}", args.Diagnostic.Message);
+                }
+            };
+
+            var solution = await workspace.OpenSolutionAsync(solutionPath, cancellationToken: cancellationToken);
+
+            _logger.LogInformation("Solution loaded with {ProjectCount} projects", solution.Projects.Count());
+
+            // Find the target type
+            var (targetSymbol, targetDocument) = await FindTypeAsync(solution, fullyQualifiedTypeName, cancellationToken);
+
+            if (targetSymbol == null || targetDocument == null)
+            {
+                result.ErrorMessage = $"Type '{fullyQualifiedTypeName}' not found in solution.";
+                return result;
+            }
+
+            _logger.LogInformation("Found target type: {TypeName} in {FilePath}",
+                targetSymbol.ToDisplayString(), targetDocument.FilePath);
+
+            // Collect all related types (dependencies and references)
+            var relatedTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            var processedTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+            // Add the target type
+            relatedTypes.Add(targetSymbol);
+
+            // Find all dependencies (types the target type depends on) - recursive
+            await CollectDependenciesAsync(solution, targetSymbol, relatedTypes, processedTypes, cancellationToken);
+            result.DependencyTypeCount = relatedTypes.Count - 1;
+
+            // Find all references (types that reference the target type) - recursive
+            var referencingTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            await CollectReferencesAsync(solution, targetSymbol, relatedTypes, referencingTypes, processedTypes, cancellationToken);
+            result.DependentTypeCount = referencingTypes.Count;
+
+            _logger.LogInformation("Found {TotalTypes} related types ({Dependencies} dependencies, {References} references)",
+                relatedTypes.Count, result.DependencyTypeCount, result.DependentTypeCount);
+
+            // Collect all files containing the related types
+            var filesToInclude = await CollectFilesForTypesAsync(solution, relatedTypes, cancellationToken);
+
+            // Collect projects that contain these files
+            var projectsToInclude = filesToInclude
+                .Select(f => f.Project)
+                .Distinct()
+                .ToList();
+
+            // Determine output directory
+            var solutionDirectory = Path.GetDirectoryName(solutionPath)!;
+            var solutionName = Path.GetFileNameWithoutExtension(solutionPath);
+            outputDirectory ??= Path.Combine(solutionDirectory, $"{solutionName}.Pruned");
+
+            // Create the pruned solution
+            await CreatePrunedSolutionAsync(
+                solutionPath,
+                outputDirectory,
+                filesToInclude,
+                projectsToInclude,
+                relatedTypes,
+                cancellationToken);
+
+            result.Success = true;
+            result.PrunedSolutionPath = Path.Combine(outputDirectory, Path.GetFileName(solutionPath));
+            result.IncludedTypes = relatedTypes.Select(t => t.ToDisplayString()).OrderBy(t => t).ToList();
+            result.IncludedFiles = filesToInclude.Select(d => d.FilePath!).Where(p => p != null).OrderBy(p => p).ToList();
+            result.IncludedProjects = projectsToInclude.Select(p => p.Name).OrderBy(n => n).ToList();
+
+            _logger.LogInformation("Pruned solution created at: {OutputPath}", result.PrunedSolutionPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to prune solution");
+            result.ErrorMessage = ex.Message;
+        }
+
+        return result;
+    }
+
+    private async Task<(INamedTypeSymbol? Symbol, Document? Document)> FindTypeAsync(
+        Solution solution,
+        string fullyQualifiedTypeName,
+        CancellationToken cancellationToken)
+    {
+        foreach (var project in solution.Projects)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            var compilation = await project.GetCompilationAsync(cancellationToken);
+            if (compilation == null)
+                continue;
+
+            // Try to find the type by fully qualified name
+            var typeSymbol = compilation.GetTypeByMetadataName(fullyQualifiedTypeName);
+            if (typeSymbol != null)
+            {
+                // Find the document containing this type
+                foreach (var location in typeSymbol.Locations)
+                {
+                    if (location.SourceTree != null)
+                    {
+                        var document = solution.GetDocument(location.SourceTree);
+                        if (document != null)
+                        {
+                            return (typeSymbol, document);
+                        }
+                    }
+                }
+            }
+        }
+
+        return (null, null);
+    }
+
+    private async Task CollectDependenciesAsync(
+        Solution solution,
+        INamedTypeSymbol targetType,
+        HashSet<INamedTypeSymbol> collectedTypes,
+        HashSet<INamedTypeSymbol> processedTypes,
+        CancellationToken cancellationToken)
+    {
+        if (processedTypes.Contains(targetType))
+            return;
+
+        processedTypes.Add(targetType);
+
+        var dependencies = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        // Get dependencies from the type definition
+        CollectTypeDependencies(targetType, dependencies);
+
+        // Get dependencies from the type's members
+        foreach (var member in targetType.GetMembers())
+        {
+            CollectMemberDependencies(member, dependencies);
+        }
+
+        // Get dependencies from the type's syntax (for local variables, etc.)
+        foreach (var location in targetType.Locations)
+        {
+            if (location.SourceTree != null)
+            {
+                var document = solution.GetDocument(location.SourceTree);
+                if (document != null)
+                {
+                    await CollectSyntaxDependenciesAsync(document, targetType, dependencies, cancellationToken);
+                }
+            }
+        }
+
+        // Filter to only types defined in the solution
+        foreach (var dep in dependencies)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            if (IsTypeInSolution(solution, dep) && !collectedTypes.Contains(dep))
+            {
+                collectedTypes.Add(dep);
+                // Recursively collect dependencies of this dependency
+                await CollectDependenciesAsync(solution, dep, collectedTypes, processedTypes, cancellationToken);
+            }
+        }
+    }
+
+    private void CollectTypeDependencies(INamedTypeSymbol type, HashSet<INamedTypeSymbol> dependencies)
+    {
+        // Base type
+        if (type.BaseType != null && type.BaseType.SpecialType == SpecialType.None)
+        {
+            AddTypeAndGenericArguments(type.BaseType, dependencies);
+        }
+
+        // Implemented interfaces
+        foreach (var iface in type.Interfaces)
+        {
+            AddTypeAndGenericArguments(iface, dependencies);
+        }
+
+        // Type parameters and constraints
+        foreach (var typeParam in type.TypeParameters)
+        {
+            foreach (var constraint in typeParam.ConstraintTypes)
+            {
+                if (constraint is INamedTypeSymbol namedConstraint)
+                {
+                    AddTypeAndGenericArguments(namedConstraint, dependencies);
+                }
+            }
+        }
+
+        // Attributes
+        foreach (var attr in type.GetAttributes())
+        {
+            if (attr.AttributeClass != null)
+            {
+                AddTypeAndGenericArguments(attr.AttributeClass, dependencies);
+            }
+        }
+    }
+
+    private void CollectMemberDependencies(ISymbol member, HashSet<INamedTypeSymbol> dependencies)
+    {
+        switch (member)
+        {
+            case IFieldSymbol field:
+                AddTypeAndGenericArguments(field.Type, dependencies);
+                break;
+
+            case IPropertySymbol property:
+                AddTypeAndGenericArguments(property.Type, dependencies);
+                break;
+
+            case IMethodSymbol method:
+                AddTypeAndGenericArguments(method.ReturnType, dependencies);
+                foreach (var param in method.Parameters)
+                {
+                    AddTypeAndGenericArguments(param.Type, dependencies);
+                }
+                foreach (var typeParam in method.TypeParameters)
+                {
+                    foreach (var constraint in typeParam.ConstraintTypes)
+                    {
+                        if (constraint is INamedTypeSymbol namedConstraint)
+                        {
+                            AddTypeAndGenericArguments(namedConstraint, dependencies);
+                        }
+                    }
+                }
+                break;
+
+            case IEventSymbol evt:
+                AddTypeAndGenericArguments(evt.Type, dependencies);
+                break;
+        }
+
+        // Attributes on members
+        foreach (var attr in member.GetAttributes())
+        {
+            if (attr.AttributeClass != null)
+            {
+                AddTypeAndGenericArguments(attr.AttributeClass, dependencies);
+            }
+        }
+    }
+
+    private async Task CollectSyntaxDependenciesAsync(
+        Document document,
+        INamedTypeSymbol targetType,
+        HashSet<INamedTypeSymbol> dependencies,
+        CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+
+        if (semanticModel == null || root == null)
+            return;
+
+        // Find the type declaration
+        var typeDeclarations = root.DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .Where(td =>
+            {
+                var symbol = semanticModel.GetDeclaredSymbol(td);
+                return SymbolEqualityComparer.Default.Equals(symbol, targetType);
+            });
+
+        foreach (var typeDecl in typeDeclarations)
+        {
+            // Collect all identifier names within the type declaration
+            var identifiers = typeDecl.DescendantNodes().OfType<IdentifierNameSyntax>();
+            foreach (var identifier in identifiers)
+            {
+                var symbolInfo = semanticModel.GetSymbolInfo(identifier);
+                var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+
+                if (symbol != null)
+                {
+                    var containingType = symbol.ContainingType;
+                    if (containingType != null)
+                    {
+                        AddTypeAndGenericArguments(containingType, dependencies);
+                    }
+
+                    if (symbol is INamedTypeSymbol namedType)
+                    {
+                        AddTypeAndGenericArguments(namedType, dependencies);
+                    }
+                }
+            }
+
+            // Collect types from object creation expressions
+            var objectCreations = typeDecl.DescendantNodes().OfType<ObjectCreationExpressionSyntax>();
+            foreach (var creation in objectCreations)
+            {
+                var typeInfo = semanticModel.GetTypeInfo(creation);
+                if (typeInfo.Type is INamedTypeSymbol createdType)
+                {
+                    AddTypeAndGenericArguments(createdType, dependencies);
+                }
+            }
+
+            // Collect types from generic names
+            var genericNames = typeDecl.DescendantNodes().OfType<GenericNameSyntax>();
+            foreach (var generic in genericNames)
+            {
+                var symbolInfo = semanticModel.GetSymbolInfo(generic);
+                if (symbolInfo.Symbol is INamedTypeSymbol namedType)
+                {
+                    AddTypeAndGenericArguments(namedType, dependencies);
+                }
+            }
+        }
+    }
+
+    private async Task CollectReferencesAsync(
+        Solution solution,
+        INamedTypeSymbol targetType,
+        HashSet<INamedTypeSymbol> collectedTypes,
+        HashSet<INamedTypeSymbol> referencingTypes,
+        HashSet<INamedTypeSymbol> processedForReferences,
+        CancellationToken cancellationToken)
+    {
+        // Find all types that reference the target type
+        var newReferences = new List<INamedTypeSymbol>();
+
+        foreach (var project in solution.Projects)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            var compilation = await project.GetCompilationAsync(cancellationToken);
+            if (compilation == null)
+                continue;
+
+            foreach (var document in project.Documents)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
+                var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+                var root = await document.GetSyntaxRootAsync(cancellationToken);
+
+                if (semanticModel == null || root == null)
+                    continue;
+
+                // Find all type declarations in this document
+                var typeDeclarations = root.DescendantNodes().OfType<TypeDeclarationSyntax>();
+
+                foreach (var typeDecl in typeDeclarations)
+                {
+                    var declaredSymbol = semanticModel.GetDeclaredSymbol(typeDecl) as INamedTypeSymbol;
+                    if (declaredSymbol == null)
+                        continue;
+
+                    // Skip if already collected or is the target type
+                    if (collectedTypes.Contains(declaredSymbol) || SymbolEqualityComparer.Default.Equals(declaredSymbol, targetType))
+                        continue;
+
+                    // Check if this type references the target type
+                    if (await TypeReferencesTargetAsync(document, typeDecl, targetType, semanticModel, cancellationToken))
+                    {
+                        if (!referencingTypes.Contains(declaredSymbol))
+                        {
+                            referencingTypes.Add(declaredSymbol);
+                            newReferences.Add(declaredSymbol);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add the new references to collected types and recursively find their references
+        foreach (var reference in newReferences)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            if (!collectedTypes.Contains(reference))
+            {
+                collectedTypes.Add(reference);
+
+                // Also collect dependencies of the referencing type
+                await CollectDependenciesAsync(solution, reference, collectedTypes, processedForReferences, cancellationToken);
+
+                // Recursively find types that reference this referencing type
+                await CollectReferencesAsync(solution, reference, collectedTypes, referencingTypes, processedForReferences, cancellationToken);
+            }
+        }
+    }
+
+    private async Task<bool> TypeReferencesTargetAsync(
+        Document document,
+        TypeDeclarationSyntax typeDecl,
+        INamedTypeSymbol targetType,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        // Check all identifiers in the type declaration
+        var identifiers = typeDecl.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Where(id => id.Identifier.Text == targetType.Name);
+
+        foreach (var identifier in identifiers)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(identifier, cancellationToken);
+            var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+
+            if (symbol != null)
+            {
+                INamedTypeSymbol? referencedType = null;
+
+                if (symbol is INamedTypeSymbol namedType)
+                {
+                    referencedType = namedType;
+                }
+                else if (symbol.ContainingType != null)
+                {
+                    referencedType = symbol.ContainingType;
+                }
+
+                if (referencedType != null && SymbolEqualityComparer.Default.Equals(referencedType.OriginalDefinition, targetType.OriginalDefinition))
+                {
+                    return true;
+                }
+            }
+        }
+
+        // Check generic names
+        var genericNames = typeDecl.DescendantNodes()
+            .OfType<GenericNameSyntax>()
+            .Where(gn => gn.Identifier.Text == targetType.Name);
+
+        foreach (var generic in genericNames)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(generic, cancellationToken);
+            if (symbolInfo.Symbol is INamedTypeSymbol namedType &&
+                SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, targetType.OriginalDefinition))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void AddTypeAndGenericArguments(ITypeSymbol type, HashSet<INamedTypeSymbol> dependencies)
+    {
+        if (type is INamedTypeSymbol namedType)
+        {
+            if (namedType.SpecialType == SpecialType.None &&
+                namedType.TypeKind != TypeKind.Error &&
+                !namedType.IsAnonymousType)
+            {
+                dependencies.Add(namedType.OriginalDefinition);
+
+                // Add generic type arguments
+                foreach (var typeArg in namedType.TypeArguments)
+                {
+                    AddTypeAndGenericArguments(typeArg, dependencies);
+                }
+            }
+        }
+        else if (type is IArrayTypeSymbol arrayType)
+        {
+            AddTypeAndGenericArguments(arrayType.ElementType, dependencies);
+        }
+    }
+
+    private bool IsTypeInSolution(Solution solution, INamedTypeSymbol type)
+    {
+        foreach (var location in type.Locations)
+        {
+            if (location.SourceTree != null)
+            {
+                var document = solution.GetDocument(location.SourceTree);
+                if (document != null)
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private async Task<List<Document>> CollectFilesForTypesAsync(
+        Solution solution,
+        HashSet<INamedTypeSymbol> types,
+        CancellationToken cancellationToken)
+    {
+        var documents = new HashSet<Document>();
+
+        foreach (var type in types)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            foreach (var location in type.Locations)
+            {
+                if (location.SourceTree != null)
+                {
+                    var document = solution.GetDocument(location.SourceTree);
+                    if (document != null && document.FilePath != null)
+                    {
+                        documents.Add(document);
+                    }
+                }
+            }
+        }
+
+        return documents.ToList();
+    }
+
+    private async Task CreatePrunedSolutionAsync(
+        string originalSolutionPath,
+        string outputDirectory,
+        List<Document> filesToInclude,
+        List<Project> projectsToInclude,
+        HashSet<INamedTypeSymbol> includedTypes,
+        CancellationToken cancellationToken)
+    {
+        var originalSolutionDirectory = Path.GetDirectoryName(originalSolutionPath)!;
+        var solutionFileName = Path.GetFileName(originalSolutionPath);
+
+        // Create output directory
+        if (Directory.Exists(outputDirectory))
+        {
+            Directory.Delete(outputDirectory, true);
+        }
+        Directory.CreateDirectory(outputDirectory);
+
+        // Group documents by project
+        var documentsByProject = filesToInclude
+            .GroupBy(d => d.Project)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Track which projects we're including
+        var includedProjectPaths = new List<(string OriginalPath, string NewPath, string ProjectName)>();
+
+        foreach (var project in projectsToInclude)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            if (project.FilePath == null)
+                continue;
+
+            var projectDirectory = Path.GetDirectoryName(project.FilePath)!;
+            var relativeProjectDir = Path.GetRelativePath(originalSolutionDirectory, projectDirectory);
+            var newProjectDir = Path.Combine(outputDirectory, relativeProjectDir);
+
+            Directory.CreateDirectory(newProjectDir);
+
+            // Copy the project file
+            var projectFileName = Path.GetFileName(project.FilePath);
+            var newProjectPath = Path.Combine(newProjectDir, projectFileName);
+
+            // Read and modify the project file to only include the relevant files
+            var projectContent = await File.ReadAllTextAsync(project.FilePath, cancellationToken);
+
+            // Copy the project file (we'll let the user manage project references)
+            await File.WriteAllTextAsync(newProjectPath, projectContent, cancellationToken);
+
+            includedProjectPaths.Add((project.FilePath, newProjectPath, project.Name));
+
+            // Copy the relevant source files
+            if (documentsByProject.TryGetValue(project, out var documents))
+            {
+                foreach (var document in documents)
+                {
+                    if (document.FilePath == null)
+                        continue;
+
+                    var relativeFilePath = Path.GetRelativePath(projectDirectory, document.FilePath);
+                    var newFilePath = Path.Combine(newProjectDir, relativeFilePath);
+                    var newFileDir = Path.GetDirectoryName(newFilePath)!;
+
+                    Directory.CreateDirectory(newFileDir);
+
+                    // Copy the source file
+                    File.Copy(document.FilePath, newFilePath, true);
+                }
+            }
+        }
+
+        // Create the solution file
+        var newSolutionPath = Path.Combine(outputDirectory, solutionFileName);
+        await CreateSolutionFileAsync(newSolutionPath, includedProjectPaths, originalSolutionPath, cancellationToken);
+
+        _logger.LogInformation("Created pruned solution with {ProjectCount} projects and {FileCount} files",
+            includedProjectPaths.Count, filesToInclude.Count);
+    }
+
+    private async Task CreateSolutionFileAsync(
+        string solutionPath,
+        List<(string OriginalPath, string NewPath, string ProjectName)> projects,
+        string originalSolutionPath,
+        CancellationToken cancellationToken)
+    {
+        var solutionDir = Path.GetDirectoryName(solutionPath)!;
+        var solutionLines = new List<string>
+        {
+            "",
+            "Microsoft Visual Studio Solution File, Format Version 12.00",
+            "# Visual Studio Version 17",
+            "VisualStudioVersion = 17.0.31903.59",
+            "MinimumVisualStudioVersion = 10.0.40219.1"
+        };
+
+        // Read original solution to get project GUIDs
+        var originalContent = await File.ReadAllTextAsync(originalSolutionPath, cancellationToken);
+        var projectGuidMap = new Dictionary<string, Guid>();
+
+        // Parse project GUIDs from original solution
+        var projectPattern = @"Project\(""\{([^}]+)\}""\)\s*=\s*""([^""]+)""\s*,\s*""([^""]+)""\s*,\s*""\{([^}]+)\}""";
+        var matches = System.Text.RegularExpressions.Regex.Matches(originalContent, projectPattern);
+        foreach (System.Text.RegularExpressions.Match match in matches)
+        {
+            var projectPath = match.Groups[3].Value;
+            var projectGuid = match.Groups[4].Value;
+            projectGuidMap[Path.GetFileName(projectPath)] = Guid.Parse(projectGuid);
+        }
+
+        // Add projects
+        foreach (var (originalPath, newPath, projectName) in projects)
+        {
+            var relativePath = Path.GetRelativePath(solutionDir, newPath);
+            var projectFileName = Path.GetFileName(newPath);
+            var projectGuid = projectGuidMap.GetValueOrDefault(projectFileName, Guid.NewGuid());
+            var typeGuid = "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC"; // C# project type GUID
+
+            solutionLines.Add($"Project(\"{{{typeGuid}}}\") = \"{projectName}\", \"{relativePath}\", \"{{{projectGuid}}}\"");
+            solutionLines.Add("EndProject");
+        }
+
+        solutionLines.Add("Global");
+        solutionLines.Add("\tGlobalSection(SolutionConfigurationPlatforms) = preSolution");
+        solutionLines.Add("\t\tDebug|Any CPU = Debug|Any CPU");
+        solutionLines.Add("\t\tRelease|Any CPU = Release|Any CPU");
+        solutionLines.Add("\tEndGlobalSection");
+        solutionLines.Add("\tGlobalSection(ProjectConfigurationPlatforms) = postSolution");
+
+        foreach (var (originalPath, newPath, projectName) in projects)
+        {
+            var projectFileName = Path.GetFileName(newPath);
+            var projectGuid = projectGuidMap.GetValueOrDefault(projectFileName, Guid.NewGuid());
+
+            solutionLines.Add($"\t\t{{{projectGuid}}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU");
+            solutionLines.Add($"\t\t{{{projectGuid}}}.Debug|Any CPU.Build.0 = Debug|Any CPU");
+            solutionLines.Add($"\t\t{{{projectGuid}}}.Release|Any CPU.ActiveCfg = Release|Any CPU");
+            solutionLines.Add($"\t\t{{{projectGuid}}}.Release|Any CPU.Build.0 = Release|Any CPU");
+        }
+
+        solutionLines.Add("\tEndGlobalSection");
+        solutionLines.Add("EndGlobal");
+        solutionLines.Add("");
+
+        await File.WriteAllLinesAsync(solutionPath, solutionLines, cancellationToken);
+    }
+}


### PR DESCRIPTION
- Add ISolutionPruneService interface and SolutionPruneService implementation in Endpoint.Engineering for pruning .NET solutions by type
- Service uses Roslyn to analyze type dependencies and references recursively
- Add PruneByType command in Endpoint.Engineering.Cli with options for type name, solution path, output directory, and verbose output
- Register SolutionPruneService in ConfigureServices