### PR TITLE
Add support for private git hosts in Take command

### DIFF
--- a/src/Endpoint.Engineering.Cli/Commands/Take.cs
+++ b/src/Endpoint.Engineering.Cli/Commands/Take.cs
@@ -13,7 +13,8 @@ using Microsoft.Extensions.Logging;
 namespace Endpoint.Engineering.Cli.Commands;
 
 /// <summary>
-/// Command to take a folder from a git/gitlab repository and copy it to a target directory.
+/// Command to take a folder from a Git repository and copy it to a target directory.
+/// Supports GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, and private/self-hosted git hosts.
 /// If the folder contains a .csproj, it will create/update a solution.
 /// If the folder is an Angular workspace project, it will create/update the workspace.
 /// </summary>
@@ -21,10 +22,11 @@ namespace Endpoint.Engineering.Cli.Commands;
 public class TakeRequest : IRequest
 {
     /// <summary>
-    /// The full GitHub or GitLab URL to a folder (e.g., https://github.com/owner/repo/tree/branch/path/to/folder).
+    /// The full Git URL to a folder.
+    /// Supports GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, and private/self-hosted git hosts.
     /// This URL will be parsed to extract the repository URL, branch, and folder path.
     /// </summary>
-    [Option('u', "url", Required = true, HelpText = "Full GitHub or GitLab URL to the folder (e.g., https://github.com/owner/repo/tree/branch/path/to/folder).")]
+    [Option('u', "url", Required = true, HelpText = "Full Git URL to the folder (supports GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, and private git hosts).")]
     public string Url { get; set; } = string.Empty;
 
     /// <summary>
@@ -64,7 +66,7 @@ public class TakeRequestHandler : IRequestHandler<TakeRequest>
         // Validate URL is provided
         if (string.IsNullOrEmpty(request.Url))
         {
-            _logger.LogError("URL is required. Please provide a full GitHub or GitLab URL to a folder.");
+            _logger.LogError("URL is required. Please provide a full Git URL to a folder.");
             _logger.LogInformation("Example: https://github.com/owner/repo/tree/branch/path/to/folder");
             return;
         }
@@ -73,9 +75,13 @@ public class TakeRequestHandler : IRequestHandler<TakeRequest>
         var parsedUrl = GitUrlParser.Parse(request.Url);
         if (parsedUrl == null)
         {
-            _logger.LogError("Invalid URL format. The URL must be a GitHub or GitLab URL to a folder.");
-            _logger.LogInformation("GitHub example: https://github.com/owner/repo/tree/branch/path/to/folder");
-            _logger.LogInformation("GitLab example: https://gitlab.com/owner/repo/-/tree/branch/path/to/folder");
+            _logger.LogError("Invalid URL format. The URL must be a valid Git URL to a folder.");
+            _logger.LogInformation("GitHub/GitHub Enterprise: https://github.com/owner/repo/tree/branch/path");
+            _logger.LogInformation("GitLab/Self-hosted GitLab: https://gitlab.com/owner/repo/-/tree/branch/path");
+            _logger.LogInformation("Bitbucket Cloud: https://bitbucket.org/owner/repo/src/branch/path");
+            _logger.LogInformation("Bitbucket Server: https://bitbucket.company.com/projects/PROJ/repos/repo/browse/path?at=branch");
+            _logger.LogInformation("Azure DevOps: https://dev.azure.com/org/project/_git/repo?path=/path&version=GBbranch");
+            _logger.LogInformation("Gitea/Gogs: https://gitea.company.com/owner/repo/src/branch/branch-name/path");
             return;
         }
 

--- a/tests/Endpoint.Engineering.UnitTests/ALaCarte/GitUrlParserTests.cs
+++ b/tests/Endpoint.Engineering.UnitTests/ALaCarte/GitUrlParserTests.cs
@@ -86,7 +86,209 @@ public class GitUrlParserTests
         "https://gitlab.example.com/owner/repo",
         "main",
         "src/folder")]
+    [InlineData(
+        "https://git.company.com/owner/repo/-/tree/develop/path/to/folder",
+        "https://git.company.com/owner/repo",
+        "develop",
+        "path/to/folder")]
+    [InlineData(
+        "https://code.internal.net/team/project/-/tree/feature/my-feature/src",
+        "https://code.internal.net/team/project",
+        "feature/my-feature",
+        "src")]
     public void Parse_SelfHostedGitLabUrl_ReturnsCorrectComponents(
+        string url,
+        string expectedRepoUrl,
+        string expectedBranch,
+        string expectedFolderPath)
+    {
+        // Act
+        var result = GitUrlParser.Parse(url);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedRepoUrl, result.Value.RepositoryUrl);
+        Assert.Equal(expectedBranch, result.Value.Branch);
+        Assert.Equal(expectedFolderPath, result.Value.FolderPath);
+    }
+
+    [Theory]
+    [InlineData(
+        "https://github.company.com/owner/repo/tree/main/src/folder",
+        "https://github.company.com/owner/repo",
+        "main",
+        "src/folder")]
+    [InlineData(
+        "https://git.enterprise.org/team/project/tree/develop/path/to/folder",
+        "https://git.enterprise.org/team/project",
+        "develop",
+        "path/to/folder")]
+    [InlineData(
+        "https://code.internal.net/owner/repo/tree/feature/branch-name/src",
+        "https://code.internal.net/owner/repo",
+        "feature/branch-name",
+        "src")]
+    public void Parse_SelfHostedGitHubEnterpriseUrl_ReturnsCorrectComponents(
+        string url,
+        string expectedRepoUrl,
+        string expectedBranch,
+        string expectedFolderPath)
+    {
+        // Act
+        var result = GitUrlParser.Parse(url);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedRepoUrl, result.Value.RepositoryUrl);
+        Assert.Equal(expectedBranch, result.Value.Branch);
+        Assert.Equal(expectedFolderPath, result.Value.FolderPath);
+    }
+
+    [Theory]
+    [InlineData(
+        "https://bitbucket.org/owner/repo/src/main/src/folder",
+        "https://bitbucket.org/owner/repo",
+        "main",
+        "src/folder")]
+    [InlineData(
+        "https://bitbucket.org/owner/repo/src/develop/path/to/project",
+        "https://bitbucket.org/owner/repo",
+        "develop",
+        "path/to/project")]
+    [InlineData(
+        "https://bitbucket.org/owner/repo/src/feature/branch-name/folder",
+        "https://bitbucket.org/owner/repo",
+        "feature/branch-name",
+        "folder")]
+    public void Parse_BitbucketCloudUrl_ReturnsCorrectComponents(
+        string url,
+        string expectedRepoUrl,
+        string expectedBranch,
+        string expectedFolderPath)
+    {
+        // Act
+        var result = GitUrlParser.Parse(url);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedRepoUrl, result.Value.RepositoryUrl);
+        Assert.Equal(expectedBranch, result.Value.Branch);
+        Assert.Equal(expectedFolderPath, result.Value.FolderPath);
+    }
+
+    [Theory]
+    [InlineData(
+        "https://bitbucket.company.com/projects/PROJ/repos/myrepo/browse/src/folder?at=refs/heads/main",
+        "https://bitbucket.company.com/projects/PROJ/repos/myrepo",
+        "main",
+        "src/folder")]
+    [InlineData(
+        "https://bitbucket.company.com/projects/TEAM/repos/app/browse?at=refs/heads/develop",
+        "https://bitbucket.company.com/projects/TEAM/repos/app",
+        "develop",
+        "")]
+    [InlineData(
+        "https://stash.internal.net/projects/DEV/repos/service/browse/path/to/folder?at=feature/my-feature",
+        "https://stash.internal.net/projects/DEV/repos/service",
+        "feature/my-feature",
+        "path/to/folder")]
+    public void Parse_BitbucketServerUrl_ReturnsCorrectComponents(
+        string url,
+        string expectedRepoUrl,
+        string expectedBranch,
+        string expectedFolderPath)
+    {
+        // Act
+        var result = GitUrlParser.Parse(url);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedRepoUrl, result.Value.RepositoryUrl);
+        Assert.Equal(expectedBranch, result.Value.Branch);
+        Assert.Equal(expectedFolderPath, result.Value.FolderPath);
+    }
+
+    [Theory]
+    [InlineData(
+        "https://dev.azure.com/myorg/myproject/_git/myrepo?path=/src/folder&version=GBmain",
+        "https://dev.azure.com/myorg/myproject/_git/myrepo",
+        "main",
+        "src/folder")]
+    [InlineData(
+        "https://dev.azure.com/company/project/_git/repo?path=/path/to/folder&version=GBdevelop",
+        "https://dev.azure.com/company/project/_git/repo",
+        "develop",
+        "path/to/folder")]
+    [InlineData(
+        "https://dev.azure.com/org/proj/_git/repo?version=GBfeature/my-branch&path=/src",
+        "https://dev.azure.com/org/proj/_git/repo",
+        "feature/my-branch",
+        "src")]
+    [InlineData(
+        "https://dev.azure.com/org/proj/_git/repo",
+        "https://dev.azure.com/org/proj/_git/repo",
+        "main",
+        "")]
+    public void Parse_AzureDevOpsUrl_ReturnsCorrectComponents(
+        string url,
+        string expectedRepoUrl,
+        string expectedBranch,
+        string expectedFolderPath)
+    {
+        // Act
+        var result = GitUrlParser.Parse(url);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedRepoUrl, result.Value.RepositoryUrl);
+        Assert.Equal(expectedBranch, result.Value.Branch);
+        Assert.Equal(expectedFolderPath, result.Value.FolderPath);
+    }
+
+    [Theory]
+    [InlineData(
+        "https://mycompany.visualstudio.com/myproject/_git/myrepo?path=/src/folder&version=GBmain",
+        "https://mycompany.visualstudio.com/myproject/_git/myrepo",
+        "main",
+        "src/folder")]
+    [InlineData(
+        "https://company.visualstudio.com/project/_git/repo?version=GBdevelop",
+        "https://company.visualstudio.com/project/_git/repo",
+        "develop",
+        "")]
+    public void Parse_LegacyVstsUrl_ReturnsCorrectComponents(
+        string url,
+        string expectedRepoUrl,
+        string expectedBranch,
+        string expectedFolderPath)
+    {
+        // Act
+        var result = GitUrlParser.Parse(url);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedRepoUrl, result.Value.RepositoryUrl);
+        Assert.Equal(expectedBranch, result.Value.Branch);
+        Assert.Equal(expectedFolderPath, result.Value.FolderPath);
+    }
+
+    [Theory]
+    [InlineData(
+        "https://gitea.company.com/owner/repo/src/branch/main/src/folder",
+        "https://gitea.company.com/owner/repo",
+        "main",
+        "src/folder")]
+    [InlineData(
+        "https://gogs.internal.net/team/project/src/branch/develop/path/to/folder",
+        "https://gogs.internal.net/team/project",
+        "develop",
+        "path/to/folder")]
+    [InlineData(
+        "https://git.mycompany.io/owner/repo/src/branch/feature/my-feature/src",
+        "https://git.mycompany.io/owner/repo",
+        "feature/my-feature",
+        "src")]
+    public void Parse_GiteaGogsUrl_ReturnsCorrectComponents(
         string url,
         string expectedRepoUrl,
         string expectedBranch,
@@ -130,6 +332,12 @@ public class GitUrlParserTests
     [Theory]
     [InlineData("https://github.com/owner/repo/tree/main/src/folder", true)]
     [InlineData("https://gitlab.com/owner/repo/-/tree/main/src/folder", true)]
+    [InlineData("https://bitbucket.org/owner/repo/src/main/src/folder", true)]
+    [InlineData("https://dev.azure.com/org/project/_git/repo?path=/src&version=GBmain", true)]
+    [InlineData("https://gitea.company.com/owner/repo/src/branch/main/folder", true)]
+    [InlineData("https://github.company.com/owner/repo/tree/main/folder", true)]
+    [InlineData("https://git.company.com/owner/repo/-/tree/main/folder", true)]
+    [InlineData("https://bitbucket.company.com/projects/PROJ/repos/repo/browse/folder?at=main", true)]
     [InlineData("https://github.com/owner/repo", false)]
     [InlineData("", false)]
     public void IsValidGitUrl_ReturnsExpectedResult(string? url, bool expected)


### PR DESCRIPTION
Extend GitUrlParser to support URLs from:
- GitHub Enterprise (self-hosted)
- Self-hosted GitLab instances (any domain)
- Bitbucket Cloud and Bitbucket Server
- Azure DevOps and legacy VSTS
- Gitea and Gogs

Update Take command help text to reflect new supported URL formats
and add comprehensive unit tests for all new URL patterns.