### PR TITLE
Support GitSCM URLs with tree paths

### DIFF
--- a/src/Endpoint.Engineering/ALaCarte/GitUrlParser.cs
+++ b/src/Endpoint.Engineering/ALaCarte/GitUrlParser.cs
@@ -282,6 +282,13 @@ public static class GitUrlParser
     /// <returns>A tuple containing (repositoryUrl, branch, folderPath).</returns>
     private static (string RepositoryUrl, string Branch, string FolderPath) ParseBranchAndPath(string repoUrl, string afterTree)
     {
+        // Strip query string if present (e.g., ?ref_type=heads from GitLab URLs)
+        var queryIndex = afterTree.IndexOf('?');
+        if (queryIndex >= 0)
+        {
+            afterTree = afterTree.Substring(0, queryIndex);
+        }
+
         var segments = afterTree.Split('/');
         
         if (segments.Length == 1)

--- a/tests/Endpoint.Engineering.UnitTests/ALaCarte/GitUrlParserTests.cs
+++ b/tests/Endpoint.Engineering.UnitTests/ALaCarte/GitUrlParserTests.cs
@@ -96,6 +96,11 @@ public class GitUrlParserTests
         "https://code.internal.net/team/project",
         "feature/my-feature",
         "src")]
+    [InlineData(
+        "https://gitscm.nike.ca/ahtletes/michael-jordan/-/tree/main/infra/data?ref_type=heads",
+        "https://gitscm.nike.ca/ahtletes/michael-jordan",
+        "main",
+        "infra/data")]
     public void Parse_SelfHostedGitLabUrl_ReturnsCorrectComponents(
         string url,
         string expectedRepoUrl,


### PR DESCRIPTION
Strip query string parameters (e.g., ?ref_type=heads) from git URLs in ParseBranchAndPath method to correctly parse self-hosted GitLab URLs like https://gitscm.nike.ca/owner/repo/-/tree/main/path?ref_type=heads