### PR TITLE
Add git repository URL support to code parser

### DIFF
--- a/src/Endpoint.Engineering.Cli/Commands/CodeParse.cs
+++ b/src/Endpoint.Engineering.Cli/Commands/CodeParse.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CommandLine;
 using Endpoint.Engineering.AI.Services;
+using Endpoint.Engineering.ALaCarte;
 using Endpoint.Services;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -24,6 +25,10 @@ public class CodeParseRequest : IRequest
     [Option('d', "directory", Required = false,
         HelpText = "Comma-separated list of directories to parse (defaults to current directory)")]
     public string? Directories { get; set; }
+
+    [Option('u', "url", Required = false,
+        HelpText = "Git repository URL to clone and parse (supports GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, and private git hosts)")]
+    public string? Url { get; set; }
 
     [Option('o', "output", Required = false, HelpText = "Output file path (optional, prints to console if not specified)")]
     public string? Output { get; set; }
@@ -46,15 +51,18 @@ public class CodeParseRequestHandler : IRequestHandler<CodeParseRequest>
     private readonly ILogger<CodeParseRequestHandler> _logger;
     private readonly ICodeParser _codeParser;
     private readonly IClipboardService _clipboardService;
+    private readonly ICommandService _commandService;
 
     public CodeParseRequestHandler(
         ILogger<CodeParseRequestHandler> logger,
         ICodeParser codeParser,
-        IClipboardService clipboardService)
+        IClipboardService clipboardService,
+        ICommandService commandService)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _codeParser = codeParser ?? throw new ArgumentNullException(nameof(codeParser));
         _clipboardService = clipboardService ?? throw new ArgumentNullException(nameof(clipboardService));
+        _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
     }
 
     public async Task Handle(CodeParseRequest request, CancellationToken cancellationToken)
@@ -79,64 +87,198 @@ public class CodeParseRequestHandler : IRequestHandler<CodeParseRequest>
             TestsOnly = request.TestsOnly
         };
 
-        // Parse directories - default to current directory if not specified
-        var directories = ParseDirectories(request.Directories);
+        string? tempDirectory = null;
+        List<string> directories;
 
-        var filterMode = request.TestsOnly ? " (tests only)" :
-                         request.IgnoreTests ? " (ignoring tests)" : "";
-
-        _logger.LogInformation("Parsing {DirectoryCount} directory(s){FilterMode} with efficiency: {Efficiency}",
-            directories.Count, filterMode, options.Efficiency);
-
-        // Parse all directories and merge results
-        var mergedSummary = new CodeSummary
+        try
         {
-            RootDirectory = directories.Count == 1 ? directories[0] : string.Join(", ", directories.Select(Path.GetFileName)),
-            Efficiency = options.Efficiency
-        };
-
-        foreach (var directory in directories)
-        {
-            if (!Directory.Exists(directory))
+            // Check if URL is provided - if so, clone the repository
+            if (!string.IsNullOrWhiteSpace(request.Url))
             {
-                _logger.LogWarning("Directory not found: {Directory}", directory);
-                continue;
+                var cloneResult = CloneRepository(request.Url);
+                if (cloneResult == null)
+                {
+                    return;
+                }
+
+                tempDirectory = cloneResult.Value.TempDirectory;
+                directories = [cloneResult.Value.ParseDirectory];
+            }
+            else
+            {
+                // Parse directories - default to current directory if not specified
+                directories = ParseDirectories(request.Directories);
             }
 
-            _logger.LogInformation("Parsing directory: {Directory}", directory);
-            var summary = await _codeParser.ParseDirectoryAsync(directory, options, cancellationToken);
+            var filterMode = request.TestsOnly ? " (tests only)" :
+                             request.IgnoreTests ? " (ignoring tests)" : "";
 
-            // Merge files into combined summary
-            mergedSummary.Files.AddRange(summary.Files);
-            mergedSummary.TotalFiles += summary.TotalFiles;
+            _logger.LogInformation("Parsing {DirectoryCount} directory(s){FilterMode} with efficiency: {Efficiency}",
+                directories.Count, filterMode, options.Efficiency);
+
+            // Parse all directories and merge results
+            var mergedSummary = new CodeSummary
+            {
+                RootDirectory = directories.Count == 1 ? directories[0] : string.Join(", ", directories.Select(Path.GetFileName)),
+                Efficiency = options.Efficiency
+            };
+
+            foreach (var directory in directories)
+            {
+                if (!Directory.Exists(directory))
+                {
+                    _logger.LogWarning("Directory not found: {Directory}", directory);
+                    continue;
+                }
+
+                _logger.LogInformation("Parsing directory: {Directory}", directory);
+                var summary = await _codeParser.ParseDirectoryAsync(directory, options, cancellationToken);
+
+                // Merge files into combined summary
+                mergedSummary.Files.AddRange(summary.Files);
+                mergedSummary.TotalFiles += summary.TotalFiles;
+            }
+
+            var output = mergedSummary.ToLlmString();
+
+            if (!string.IsNullOrEmpty(request.Output))
+            {
+                var outputPath = request.Output;
+                if (!string.IsNullOrEmpty(request.Name))
+                {
+                    outputPath = Path.Combine(
+                        Path.GetDirectoryName(request.Output) ?? directories[0],
+                        $"{request.Name}.txt");
+                }
+
+                await File.WriteAllTextAsync(outputPath, output, cancellationToken);
+                _logger.LogInformation("Output written to: {OutputPath}", outputPath);
+            }
+            else
+            {
+                Console.WriteLine(output);
+            }
+
+            _logger.LogInformation("Parsed {FileCount} files from {DirectoryCount} directory(s) with efficiency {Efficiency} ({OutputLength} chars)",
+                mergedSummary.Files.Count, directories.Count, options.Efficiency, output.Length);
+
+            // Copy result to clipboard
+            _clipboardService.SetText(output);
+            _logger.LogInformation("Result copied to clipboard");
         }
-
-        var output = mergedSummary.ToLlmString();
-
-        if (!string.IsNullOrEmpty(request.Output))
+        finally
         {
-            var outputPath = request.Output;
-            if (!string.IsNullOrEmpty(request.Name))
+            // Clean up temp directory if it was created
+            if (!string.IsNullOrEmpty(tempDirectory) && Directory.Exists(tempDirectory))
             {
-                outputPath = Path.Combine(
-                    Path.GetDirectoryName(request.Output) ?? directories[0],
-                    $"{request.Name}.txt");
+                try
+                {
+                    Directory.Delete(tempDirectory, recursive: true);
+                    _logger.LogInformation("Cleaned up temporary directory: {TempDirectory}", tempDirectory);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to clean up temporary directory: {TempDirectory}", tempDirectory);
+                }
             }
+        }
+    }
 
-            await File.WriteAllTextAsync(outputPath, output, cancellationToken);
-            _logger.LogInformation("Output written to: {OutputPath}", outputPath);
+    /// <summary>
+    /// Clones a git repository to a temporary directory.
+    /// </summary>
+    /// <param name="url">The git repository URL (can be a direct clone URL or a tree URL).</param>
+    /// <returns>A tuple with the temp directory and the directory to parse, or null if cloning fails.</returns>
+    private (string TempDirectory, string ParseDirectory)? CloneRepository(string url)
+    {
+        // Try to parse as a tree URL (e.g., GitHub/GitLab folder URL)
+        var parsedUrl = GitUrlParser.Parse(url);
+
+        string repoUrl;
+        string? branch = null;
+        string? folderPath = null;
+
+        if (parsedUrl != null)
+        {
+            repoUrl = parsedUrl.Value.RepositoryUrl;
+            branch = parsedUrl.Value.Branch;
+            folderPath = parsedUrl.Value.FolderPath;
+
+            _logger.LogInformation(
+                "Parsed URL - Repository: {Url}, Branch: {Branch}, Folder: {Path}",
+                repoUrl,
+                branch,
+                string.IsNullOrEmpty(folderPath) ? "(root)" : folderPath);
         }
         else
         {
-            Console.WriteLine(output);
+            // Assume it's a direct clone URL
+            repoUrl = url;
+            _logger.LogInformation("Using URL as direct clone URL: {Url}", repoUrl);
         }
 
-        _logger.LogInformation("Parsed {FileCount} files from {DirectoryCount} directory(s) with efficiency {Efficiency} ({OutputLength} chars)",
-            mergedSummary.Files.Count, directories.Count, options.Efficiency, output.Length);
+        // Create temp directory
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"code-parse-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
 
-        // Copy result to clipboard
-        _clipboardService.SetText(output);
-        _logger.LogInformation("Result copied to clipboard");
+        _logger.LogInformation("Cloning repository to temporary directory: {TempDirectory}", tempDirectory);
+
+        // Build git clone command
+        var cloneCommand = $"git clone --depth 1";
+
+        if (!string.IsNullOrEmpty(branch))
+        {
+            cloneCommand += $" --branch {branch}";
+        }
+
+        cloneCommand += $" \"{repoUrl}\" \"{tempDirectory}\"";
+
+        // Execute git clone
+        var exitCode = _commandService.Start(cloneCommand);
+
+        if (exitCode != 0)
+        {
+            _logger.LogError("Failed to clone repository. Exit code: {ExitCode}", exitCode);
+
+            // Clean up temp directory on failure
+            try
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+
+            return null;
+        }
+
+        _logger.LogInformation("Successfully cloned repository");
+
+        // Determine the directory to parse
+        var parseDirectory = tempDirectory;
+        if (!string.IsNullOrEmpty(folderPath))
+        {
+            parseDirectory = Path.Combine(tempDirectory, folderPath);
+            if (!Directory.Exists(parseDirectory))
+            {
+                _logger.LogError("Folder path not found in repository: {FolderPath}", folderPath);
+
+                // Clean up temp directory on failure
+                try
+                {
+                    Directory.Delete(tempDirectory, recursive: true);
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+
+                return null;
+            }
+        }
+
+        return (tempDirectory, parseDirectory);
     }
 
     private static List<string> ParseDirectories(string? directoriesArg)


### PR DESCRIPTION
Allow users to specify a git repository URL (-u/--url) to clone and parse. The system clones the repo to a temp folder using git command line (shallow clone with --depth 1), parses the code, and cleans up automatically.

Supports all URL formats from GitUrlParser (GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, and private git hosts). Can parse specific branches and folder paths when provided in tree URLs.