### PR TITLE
Fix Angular folder cloning with two segments

### DIFF
--- a/src/Endpoint.Engineering.Cli/Commands/Take.cs
+++ b/src/Endpoint.Engineering.Cli/Commands/Take.cs
@@ -40,6 +40,15 @@ public class TakeRequest : IRequest
     /// </summary>
     [Option('s', "solution", Required = false, HelpText = "The name of the solution to create/update.")]
     public string? SolutionName { get; set; }
+
+    /// <summary>
+    /// The root path for Angular projects within the angular.json workspace configuration.
+    /// When specified, this value is used as the "root" property in angular.json instead of
+    /// deriving it from the destination path. This is useful when the Angular library root
+    /// has multiple segments (e.g., "nike/utils" instead of just "utils").
+    /// </summary>
+    [Option('r', "root", Required = false, HelpText = "The Angular library root path for angular.json (e.g., \"nike/utils\").")]
+    public string? Root { get; set; }
 }
 
 /// <summary>
@@ -99,7 +108,8 @@ public class TakeRequestHandler : IRequestHandler<TakeRequest>
             Branch = branch,
             FromPath = folderPath,
             Directory = request.Directory,
-            SolutionName = request.SolutionName
+            SolutionName = request.SolutionName,
+            Root = request.Root
         };
 
         _logger.LogInformation(

--- a/src/Endpoint.Engineering/ALaCarte/Models/ALaCarteResult.cs
+++ b/src/Endpoint.Engineering/ALaCarte/Models/ALaCarteResult.cs
@@ -34,6 +34,12 @@ public class ALaCarteResult
     public List<string> AngularWorkspacesCreated { get; set; } = new();
 
     /// <summary>
+    /// Mapping of destination folder paths to their custom Angular root values.
+    /// Used when creating angular.json workspaces for folders with custom root specifications.
+    /// </summary>
+    public Dictionary<string, string> AngularRootMappings { get; set; } = new();
+
+    /// <summary>
     /// List of error messages if any operations failed.
     /// </summary>
     public List<string> Errors { get; set; } = new();

--- a/src/Endpoint.Engineering/ALaCarte/Models/ALaCarteTakeRequest.cs
+++ b/src/Endpoint.Engineering/ALaCarte/Models/ALaCarteTakeRequest.cs
@@ -35,4 +35,12 @@ public class ALaCarteTakeRequest
     /// If not specified and a .csproj is found, defaults to the folder name.
     /// </summary>
     public string? SolutionName { get; set; }
+
+    /// <summary>
+    /// The root path for Angular projects within the angular.json workspace configuration.
+    /// When specified, this value is used as the "root" property in angular.json instead of
+    /// deriving it from the destination path. This is useful when the Angular library root
+    /// has multiple segments (e.g., "nike/utils" instead of just "utils").
+    /// </summary>
+    public string? Root { get; set; }
 }

--- a/src/Endpoint.Engineering/ALaCarte/Models/FolderConfiguration.cs
+++ b/src/Endpoint.Engineering/ALaCarte/Models/FolderConfiguration.cs
@@ -17,4 +17,12 @@ public class FolderConfiguration
     /// The destination path to copy to (relative to the output directory).
     /// </summary>
     public string To { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The root path for Angular projects within the angular.json workspace configuration.
+    /// When specified, this value is used as the "root" property in angular.json instead of
+    /// deriving it from the destination path. This is useful when the Angular library root
+    /// has multiple segments (e.g., "nike/utils" instead of just "utils").
+    /// </summary>
+    public string? Root { get; set; }
 }


### PR DESCRIPTION
Add a "root" property to FolderConfiguration for a-la-carte and a "--root" argument to the take command. This allows specifying a custom root path for angular.json configuration when the Angular library root has multiple segments (e.g., "nike/utils" instead of just "utils").

Changes:
- Add Root property to FolderConfiguration and ALaCarteTakeRequest models
- Add -r/--root CLI option to the take command
- Update AngularWorkspaceHelper to accept custom root and position angular.json at the appropriate parent directory level
- Update ALaCarteService to track and pass through root mappings
- Add AngularRootMappings dictionary to ALaCarteResult for tracking