### PR TITLE
Add ALaCarteRequest CRUD operations and controller

### DIFF
--- a/src/Endpoint.Engineering.ALaCarte.Api/Controllers/ALaCarteRequestsController.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Controllers/ALaCarteRequestsController.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Commands.CreateALaCarteRequest;
+using Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Commands.DeleteALaCarteRequest;
+using Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Commands.UpdateALaCarteRequest;
+using Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Queries.GetALaCarteRequest;
+using Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Queries.GetALaCarteRequests;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ALaCarteRequestsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<ALaCarteRequestsController> _logger;
+
+    public ALaCarteRequestsController(IMediator mediator, ILogger<ALaCarteRequestsController> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<GetALaCarteRequestsResponse>> GetAll(CancellationToken cancellationToken)
+    {
+        var response = await _mediator.Send(new GetALaCarteRequestsRequest(), cancellationToken);
+        return Ok(response);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<CreateALaCarteRequestResponse>> Create(
+        CreateALaCarteRequestRequest request,
+        CancellationToken cancellationToken)
+    {
+        var response = await _mediator.Send(request, cancellationToken);
+        return CreatedAtAction(nameof(Get), new { id = response.ALaCarteRequestId }, response);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<GetALaCarteRequestResponse>> Get(
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        var response = await _mediator.Send(new GetALaCarteRequestRequest { ALaCarteRequestId = id }, cancellationToken);
+        if (response == null)
+        {
+            return NotFound();
+        }
+        return Ok(response);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<ActionResult> Update(
+        Guid id,
+        UpdateALaCarteRequestRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (id != request.ALaCarteRequestId)
+        {
+            return BadRequest();
+        }
+
+        await _mediator.Send(request, cancellationToken);
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
+    {
+        await _mediator.Send(new DeleteALaCarteRequestRequest { ALaCarteRequestId = id }, cancellationToken);
+        return NoContent();
+    }
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/CreateALaCarteRequest/CreateALaCarteRequestHandler.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/CreateALaCarteRequest/CreateALaCarteRequestHandler.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Core;
+using Endpoint.Engineering.ALaCarte.Core.Models;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Commands.CreateALaCarteRequest;
+
+public class CreateALaCarteRequestHandler : IRequestHandler<CreateALaCarteRequestRequest, CreateALaCarteRequestResponse>
+{
+    private readonly IALaCarteContext _context;
+    private readonly ILogger<CreateALaCarteRequestHandler> _logger;
+
+    public CreateALaCarteRequestHandler(IALaCarteContext context, ILogger<CreateALaCarteRequestHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<CreateALaCarteRequestResponse> Handle(CreateALaCarteRequestRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Creating ALaCarte request");
+
+        var alaCarteRequest = new ALaCarteRequest
+        {
+            ALaCarteRequestId = Guid.NewGuid(),
+            OutputType = request.OutputType,
+            Directory = request.Directory,
+            SolutionName = request.SolutionName
+        };
+
+        _context.ALaCarteRequests.Add(alaCarteRequest);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Created ALaCarte request with ID: {ALaCarteRequestId}", alaCarteRequest.ALaCarteRequestId);
+
+        return new CreateALaCarteRequestResponse
+        {
+            ALaCarteRequestId = alaCarteRequest.ALaCarteRequestId
+        };
+    }
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/CreateALaCarteRequest/CreateALaCarteRequestRequest.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/CreateALaCarteRequest/CreateALaCarteRequestRequest.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Core.Models;
+using MediatR;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Commands.CreateALaCarteRequest;
+
+public class CreateALaCarteRequestRequest : IRequest<CreateALaCarteRequestResponse>
+{
+    public OutputType OutputType { get; set; } = OutputType.NotSpecified;
+    public string Directory { get; set; } = string.Empty;
+    public string SolutionName { get; set; } = "ALaCarte.sln";
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/CreateALaCarteRequest/CreateALaCarteRequestResponse.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/CreateALaCarteRequest/CreateALaCarteRequestResponse.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Commands.CreateALaCarteRequest;
+
+public class CreateALaCarteRequestResponse
+{
+    public Guid ALaCarteRequestId { get; set; }
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/DeleteALaCarteRequest/DeleteALaCarteRequestHandler.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/DeleteALaCarteRequest/DeleteALaCarteRequestHandler.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Core;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Commands.DeleteALaCarteRequest;
+
+public class DeleteALaCarteRequestHandler : IRequestHandler<DeleteALaCarteRequestRequest>
+{
+    private readonly IALaCarteContext _context;
+    private readonly ILogger<DeleteALaCarteRequestHandler> _logger;
+
+    public DeleteALaCarteRequestHandler(IALaCarteContext context, ILogger<DeleteALaCarteRequestHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(DeleteALaCarteRequestRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Deleting ALaCarte request with ID: {ALaCarteRequestId}", request.ALaCarteRequestId);
+
+        var alaCarteRequest = await _context.ALaCarteRequests
+            .FirstOrDefaultAsync(r => r.ALaCarteRequestId == request.ALaCarteRequestId, cancellationToken);
+
+        if (alaCarteRequest == null)
+        {
+            throw new InvalidOperationException($"ALaCarte request with ID {request.ALaCarteRequestId} not found");
+        }
+
+        _context.ALaCarteRequests.Remove(alaCarteRequest);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Deleted ALaCarte request with ID: {ALaCarteRequestId}", request.ALaCarteRequestId);
+    }
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/DeleteALaCarteRequest/DeleteALaCarteRequestRequest.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/DeleteALaCarteRequest/DeleteALaCarteRequestRequest.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using MediatR;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Commands.DeleteALaCarteRequest;
+
+public class DeleteALaCarteRequestRequest : IRequest
+{
+    public Guid ALaCarteRequestId { get; set; }
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/UpdateALaCarteRequest/UpdateALaCarteRequestHandler.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/UpdateALaCarteRequest/UpdateALaCarteRequestHandler.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Core;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Commands.UpdateALaCarteRequest;
+
+public class UpdateALaCarteRequestHandler : IRequestHandler<UpdateALaCarteRequestRequest>
+{
+    private readonly IALaCarteContext _context;
+    private readonly ILogger<UpdateALaCarteRequestHandler> _logger;
+
+    public UpdateALaCarteRequestHandler(IALaCarteContext context, ILogger<UpdateALaCarteRequestHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(UpdateALaCarteRequestRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Updating ALaCarte request with ID: {ALaCarteRequestId}", request.ALaCarteRequestId);
+
+        var alaCarteRequest = await _context.ALaCarteRequests
+            .FirstOrDefaultAsync(r => r.ALaCarteRequestId == request.ALaCarteRequestId, cancellationToken);
+
+        if (alaCarteRequest == null)
+        {
+            throw new InvalidOperationException($"ALaCarte request with ID {request.ALaCarteRequestId} not found");
+        }
+
+        alaCarteRequest.OutputType = request.OutputType;
+        alaCarteRequest.Directory = request.Directory;
+        alaCarteRequest.SolutionName = request.SolutionName;
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Updated ALaCarte request with ID: {ALaCarteRequestId}", request.ALaCarteRequestId);
+    }
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/UpdateALaCarteRequest/UpdateALaCarteRequestRequest.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Commands/UpdateALaCarteRequest/UpdateALaCarteRequestRequest.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Core.Models;
+using MediatR;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Commands.UpdateALaCarteRequest;
+
+public class UpdateALaCarteRequestRequest : IRequest
+{
+    public Guid ALaCarteRequestId { get; set; }
+    public OutputType OutputType { get; set; } = OutputType.NotSpecified;
+    public string Directory { get; set; } = string.Empty;
+    public string SolutionName { get; set; } = "ALaCarte.sln";
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequest/GetALaCarteRequestHandler.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequest/GetALaCarteRequestHandler.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Core;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Queries.GetALaCarteRequest;
+
+public class GetALaCarteRequestHandler : IRequestHandler<GetALaCarteRequestRequest, GetALaCarteRequestResponse?>
+{
+    private readonly IALaCarteContext _context;
+    private readonly ILogger<GetALaCarteRequestHandler> _logger;
+
+    public GetALaCarteRequestHandler(IALaCarteContext context, ILogger<GetALaCarteRequestHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GetALaCarteRequestResponse?> Handle(GetALaCarteRequestRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Getting ALaCarte request with ID: {ALaCarteRequestId}", request.ALaCarteRequestId);
+
+        var alaCarteRequest = await _context.ALaCarteRequests
+            .Where(r => r.ALaCarteRequestId == request.ALaCarteRequestId)
+            .Select(r => new GetALaCarteRequestResponse
+            {
+                ALaCarteRequestId = r.ALaCarteRequestId,
+                OutputType = r.OutputType,
+                Directory = r.Directory,
+                SolutionName = r.SolutionName
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return alaCarteRequest;
+    }
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequest/GetALaCarteRequestRequest.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequest/GetALaCarteRequestRequest.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using MediatR;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Queries.GetALaCarteRequest;
+
+public class GetALaCarteRequestRequest : IRequest<GetALaCarteRequestResponse?>
+{
+    public Guid ALaCarteRequestId { get; set; }
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequest/GetALaCarteRequestResponse.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequest/GetALaCarteRequestResponse.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Core.Models;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Queries.GetALaCarteRequest;
+
+public class GetALaCarteRequestResponse
+{
+    public Guid ALaCarteRequestId { get; set; }
+    public OutputType OutputType { get; set; }
+    public string Directory { get; set; } = string.Empty;
+    public string SolutionName { get; set; } = string.Empty;
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequests/GetALaCarteRequestsHandler.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequests/GetALaCarteRequestsHandler.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Core;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Queries.GetALaCarteRequests;
+
+public class GetALaCarteRequestsHandler : IRequestHandler<GetALaCarteRequestsRequest, GetALaCarteRequestsResponse>
+{
+    private readonly IALaCarteContext _context;
+    private readonly ILogger<GetALaCarteRequestsHandler> _logger;
+
+    public GetALaCarteRequestsHandler(IALaCarteContext context, ILogger<GetALaCarteRequestsHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GetALaCarteRequestsResponse> Handle(GetALaCarteRequestsRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Getting all ALaCarte requests");
+
+        var requests = await _context.ALaCarteRequests
+            .Select(r => new ALaCarteRequestDto
+            {
+                ALaCarteRequestId = r.ALaCarteRequestId,
+                OutputType = r.OutputType,
+                Directory = r.Directory,
+                SolutionName = r.SolutionName
+            })
+            .ToListAsync(cancellationToken);
+
+        return new GetALaCarteRequestsResponse
+        {
+            ALaCarteRequests = requests
+        };
+    }
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequests/GetALaCarteRequestsRequest.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequests/GetALaCarteRequestsRequest.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using MediatR;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Queries.GetALaCarteRequests;
+
+public class GetALaCarteRequestsRequest : IRequest<GetALaCarteRequestsResponse>
+{
+}

--- a/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequests/GetALaCarteRequestsResponse.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Api/Features/ALaCarteRequests/Queries/GetALaCarteRequests/GetALaCarteRequestsResponse.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Core.Models;
+
+namespace Endpoint.Engineering.ALaCarte.Api.Features.ALaCarteRequests.Queries.GetALaCarteRequests;
+
+public class GetALaCarteRequestsResponse
+{
+    public List<ALaCarteRequestDto> ALaCarteRequests { get; set; } = new();
+}
+
+public class ALaCarteRequestDto
+{
+    public Guid ALaCarteRequestId { get; set; }
+    public OutputType OutputType { get; set; }
+    public string Directory { get; set; } = string.Empty;
+    public string SolutionName { get; set; } = string.Empty;
+}

--- a/src/Endpoint.Engineering.ALaCarte.Core/IALaCarteContext.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Core/IALaCarteContext.cs
@@ -17,6 +17,11 @@ public interface IALaCarteContext
     DbSet<RepositoryConfiguration> RepositoryConfigurations { get; set; }
 
     /// <summary>
+    /// Gets or sets the ALaCarte requests.
+    /// </summary>
+    DbSet<ALaCarteRequest> ALaCarteRequests { get; set; }
+
+    /// <summary>
     /// Saves all changes made in this context to the database.
     /// </summary>
     /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>

--- a/src/Endpoint.Engineering.ALaCarte.Core/Models/ALaCarteRequest.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Core/Models/ALaCarteRequest.cs
@@ -9,6 +9,11 @@ namespace Endpoint.Engineering.ALaCarte.Core.Models;
 public class ALaCarteRequest
 {
     /// <summary>
+    /// The unique identifier for the ALaCarte request.
+    /// </summary>
+    public Guid ALaCarteRequestId { get; set; }
+
+    /// <summary>
     /// The list of repository configurations to process.
     /// </summary>
     public List<RepositoryConfiguration> Repositories { get; set; } = new();

--- a/src/Endpoint.Engineering.ALaCarte.Infrastructure/Data/ALaCarteContext.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Infrastructure/Data/ALaCarteContext.cs
@@ -25,6 +25,9 @@ public class ALaCarteContext : DbContext, IALaCarteContext
     public DbSet<RepositoryConfiguration> RepositoryConfigurations { get; set; } = null!;
 
     /// <inheritdoc/>
+    public DbSet<ALaCarteRequest> ALaCarteRequests { get; set; } = null!;
+
+    /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/src/Endpoint.Engineering.ALaCarte.Infrastructure/Data/Configurations/ALaCarteRequestConfiguration.cs
+++ b/src/Endpoint.Engineering.ALaCarte.Infrastructure/Data/Configurations/ALaCarteRequestConfiguration.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Endpoint.Engineering.ALaCarte.Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Endpoint.Engineering.ALaCarte.Infrastructure.Data.Configurations;
+
+/// <summary>
+/// Entity configuration for ALaCarteRequest.
+/// </summary>
+public class ALaCarteRequestConfiguration : IEntityTypeConfiguration<ALaCarteRequest>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<ALaCarteRequest> builder)
+    {
+        builder.HasKey(x => x.ALaCarteRequestId);
+
+        builder.Property(x => x.OutputType)
+            .IsRequired()
+            .HasDefaultValue(OutputType.NotSpecified);
+
+        builder.Property(x => x.Directory)
+            .HasMaxLength(500)
+            .IsRequired();
+
+        builder.Property(x => x.SolutionName)
+            .HasMaxLength(200)
+            .IsRequired()
+            .HasDefaultValue("ALaCarte.sln");
+
+        // Ignore Repositories collection as it's not stored directly - it's configuration data
+        builder.Ignore(x => x.Repositories);
+    }
+}


### PR DESCRIPTION
- Add ALaCarteRequestId property to ALaCarteRequest model for database persistence
- Add DbSet<ALaCarteRequest> to IALaCarteContext interface and ALaCarteContext
- Create ALaCarteRequestConfiguration for EF Core entity configuration
- Add Commands: CreateALaCarteRequest, UpdateALaCarteRequest, DeleteALaCarteRequest
- Add Queries: GetALaCarteRequest, GetALaCarteRequests
- Create ALaCarteRequestsController with full CRUD endpoints