### PR TITLE
Add a-la-carte-request-get command to CLI

### DIFF
--- a/src/Endpoint.Engineering.Cli/Commands/ALaCarteRequestGet.cs
+++ b/src/Endpoint.Engineering.Cli/Commands/ALaCarteRequestGet.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CommandLine;
+using Endpoint.Engineering.ALaCarte.Core;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Endpoint.Engineering.Cli.Commands;
+
+[Verb("a-la-carte-request-get", HelpText = "Display all ALaCarteRequests from the database.")]
+public class ALaCarteRequestGetRequest : IRequest
+{
+    [Option("no-color", Required = false, Default = false,
+        HelpText = "Disable colorized output.")]
+    public bool NoColor { get; set; }
+}
+
+public class ALaCarteRequestGetRequestHandler : IRequestHandler<ALaCarteRequestGetRequest>
+{
+    private readonly ILogger<ALaCarteRequestGetRequestHandler> _logger;
+    private readonly IALaCarteContext _context;
+
+    public ALaCarteRequestGetRequestHandler(
+        ILogger<ALaCarteRequestGetRequestHandler> logger,
+        IALaCarteContext context)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task Handle(ALaCarteRequestGetRequest request, CancellationToken cancellationToken)
+    {
+        WriteHeader(request.NoColor);
+
+        try
+        {
+            _logger.LogInformation("Retrieving all ALaCarte requests from database");
+
+            var requests = await _context.ALaCarteRequests.ToListAsync(cancellationToken);
+
+            if (requests.Count == 0)
+            {
+                Console.WriteLine("No ALaCarteRequests found in the database.");
+                Console.WriteLine();
+                return;
+            }
+
+            Console.WriteLine($"Found {requests.Count} ALaCarteRequest(s):");
+            Console.WriteLine();
+
+            foreach (var alaCarteRequest in requests)
+            {
+                DisplayRequest(alaCarteRequest, request.NoColor);
+            }
+        }
+        catch (Exception ex)
+        {
+            WriteError($"Error retrieving ALaCarteRequests: {ex.Message}", request.NoColor);
+            _logger.LogError(ex, "Error retrieving ALaCarteRequests");
+            Environment.ExitCode = 1;
+        }
+    }
+
+    private static void WriteHeader(bool noColor)
+    {
+        Console.WriteLine();
+        if (!noColor)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+        }
+
+        Console.WriteLine("=== ALaCarte Requests ===");
+        if (!noColor)
+        {
+            Console.ResetColor();
+        }
+
+        Console.WriteLine();
+    }
+
+    private static void WriteError(string message, bool noColor)
+    {
+        if (!noColor)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+        }
+
+        Console.WriteLine($"Error: {message}");
+        if (!noColor)
+        {
+            Console.ResetColor();
+        }
+    }
+
+    private static void DisplayRequest(Endpoint.Engineering.ALaCarte.Core.Models.ALaCarteRequest alaCarteRequest, bool noColor)
+    {
+        if (!noColor)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+        }
+
+        Console.WriteLine($"ID: {alaCarteRequest.ALaCarteRequestId}");
+        if (!noColor)
+        {
+            Console.ResetColor();
+        }
+
+        Console.WriteLine($"  Directory:     {alaCarteRequest.Directory}");
+        Console.WriteLine($"  Solution Name: {alaCarteRequest.SolutionName}");
+        Console.WriteLine($"  Output Type:   {alaCarteRequest.OutputType}");
+        Console.WriteLine();
+    }
+}

--- a/src/Endpoint.Engineering.Cli/Endpoint.Engineering.Cli.csproj
+++ b/src/Endpoint.Engineering.Cli/Endpoint.Engineering.Cli.csproj
@@ -36,6 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -53,6 +54,8 @@
     <ProjectReference Include="..\Endpoint.Angular\Endpoint.Angular.csproj" />
     <ProjectReference Include="..\Endpoint.DotNet\Endpoint.DotNet.csproj" />
     <ProjectReference Include="..\Endpoint.Engineering\Endpoint.Engineering.csproj" />
+    <ProjectReference Include="..\Endpoint.Engineering.ALaCarte.Core\Endpoint.Engineering.ALaCarte.Core.csproj" />
+    <ProjectReference Include="..\Endpoint.Engineering.ALaCarte.Infrastructure\Endpoint.Engineering.ALaCarte.Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add a new CLI command that displays all ALaCarteRequests from the SQLite database. This includes:
- New ALaCarteRequestGet.cs command with [Verb("a-la-carte-request-get")]
- DbContext registration in Program.cs using the same database path as the API
- Project references to ALaCarte.Core and ALaCarte.Infrastructure
- EF Core SQLite package reference

The command outputs each request's ID, directory, solution name, and output type with optional colorized output.