### PR TITLE
Create reusable components with tests and stories

### DIFF
--- a/src/Endpoint.Engineering.Workspace/package-lock.json
+++ b/src/Endpoint.Engineering.Workspace/package-lock.json
@@ -14,6 +14,7 @@
         "@angular/forms": "^21.0.0",
         "@angular/platform-browser": "^21.0.0",
         "@angular/router": "^21.0.0",
+        "@vitest/coverage-v8": "^4.0.17",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0"
       },
@@ -862,7 +863,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -872,7 +872,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -906,7 +905,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
       "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.6"
@@ -966,7 +964,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
       "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -974,6 +971,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -2040,7 +2046,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2061,14 +2066,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -5564,7 +5567,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/html-minifier-terser": {
@@ -5667,6 +5669,36 @@
         "vite": "^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.17.tgz",
+      "integrity": "sha512-/6zU2FLGg0jsd+ePZcwHRy3+WpNTBBhDY56P4JTRqUN/Dp6CvOEa9HrikcQ4KfV2b2kAHUFB4dl1SuocWXSFEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.17",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.17",
+        "vitest": "4.0.17"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.17",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.17.tgz",
@@ -5726,7 +5758,6 @@
       "version": "4.0.17",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.17.tgz",
       "integrity": "sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.0.3"
@@ -5778,7 +5809,6 @@
       "version": "4.0.17",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.17.tgz",
       "integrity": "sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.0.17",
@@ -6225,6 +6255,32 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
+      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -8284,7 +8340,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8406,6 +8461,12 @@
           "url": "https://patreon.com/mdevils"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "license": "MIT"
     },
     "node_modules/html-minifier-terser": {
@@ -8954,7 +9015,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -8975,6 +9035,60 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-worker": {
@@ -9422,6 +9536,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {
@@ -10240,7 +10365,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
       "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -11682,7 +11806,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11982,7 +12105,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -12079,7 +12201,6 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
@@ -12439,7 +12560,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
       "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"

--- a/src/Endpoint.Engineering.Workspace/package.json
+++ b/src/Endpoint.Engineering.Workspace/package.json
@@ -33,6 +33,7 @@
     "@angular/forms": "^21.0.0",
     "@angular/platform-browser": "^21.0.0",
     "@angular/router": "^21.0.0",
+    "@vitest/coverage-v8": "^4.0.17",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/badge.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/badge.html
@@ -1,0 +1,9 @@
+<span
+  class="badge"
+  [class.badge--success]="variant() === 'success'"
+  [class.badge--processing]="variant() === 'processing'"
+  [class.badge--pending]="variant() === 'pending'"
+  [class.badge--error]="variant() === 'error'"
+>
+  {{ label() }}
+</span>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/badge.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/badge.scss
@@ -1,0 +1,29 @@
+@use '../styles/variables';
+
+.badge {
+  display: inline-block;
+  padding: var(--ee-spacing-xs) var(--ee-spacing-sm);
+  border-radius: var(--ee-radius-sm);
+  font-size: var(--ee-font-size-xs);
+  font-weight: 500;
+
+  &--success {
+    background: rgba(129, 199, 132, 0.15);
+    color: var(--ee-success);
+  }
+
+  &--processing {
+    background: rgba(159, 168, 218, 0.15);
+    color: var(--ee-primary);
+  }
+
+  &--pending {
+    background: rgba(230, 237, 243, 0.1);
+    color: var(--ee-on-surface-medium);
+  }
+
+  &--error {
+    background: rgba(239, 83, 80, 0.15);
+    color: var(--ee-warn);
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/badge.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/badge.spec.ts
@@ -1,0 +1,58 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Badge } from './badge';
+
+describe('Badge', () => {
+  let component: Badge;
+  let fixture: ComponentFixture<Badge>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Badge],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Badge);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('label', 'Test Badge');
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the label', () => {
+    fixture.detectChanges();
+    const badgeElement = fixture.nativeElement.querySelector('.badge');
+    expect(badgeElement.textContent.trim()).toBe('Test Badge');
+  });
+
+  it('should apply pending variant by default', () => {
+    fixture.detectChanges();
+    const badgeElement = fixture.nativeElement.querySelector('.badge');
+    expect(badgeElement.classList.contains('badge--pending')).toBe(true);
+  });
+
+  it('should apply success variant', () => {
+    fixture.componentRef.setInput('variant', 'success');
+    fixture.detectChanges();
+
+    const badgeElement = fixture.nativeElement.querySelector('.badge');
+    expect(badgeElement.classList.contains('badge--success')).toBe(true);
+  });
+
+  it('should apply processing variant', () => {
+    fixture.componentRef.setInput('variant', 'processing');
+    fixture.detectChanges();
+
+    const badgeElement = fixture.nativeElement.querySelector('.badge');
+    expect(badgeElement.classList.contains('badge--processing')).toBe(true);
+  });
+
+  it('should apply error variant', () => {
+    fixture.componentRef.setInput('variant', 'error');
+    fixture.detectChanges();
+
+    const badgeElement = fixture.nativeElement.querySelector('.badge');
+    expect(badgeElement.classList.contains('badge--error')).toBe(true);
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/badge.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/badge.stories.ts
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { Badge } from './badge';
+
+const meta: Meta<Badge> = {
+  title: 'Components/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Badge label text',
+    },
+    variant: {
+      control: 'select',
+      options: ['success', 'processing', 'pending', 'error'],
+      description: 'Badge style variant',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<Badge>;
+
+export const Success: Story = {
+  args: {
+    label: 'Completed',
+    variant: 'success',
+  },
+};
+
+export const Processing: Story = {
+  args: {
+    label: 'Processing',
+    variant: 'processing',
+  },
+};
+
+export const Pending: Story = {
+  args: {
+    label: 'Pending',
+    variant: 'pending',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    label: 'Failed',
+    variant: 'error',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => ({
+    template: `
+      <div style="display: flex; gap: 12px; flex-wrap: wrap;">
+        <ee-badge label="Completed" variant="success"></ee-badge>
+        <ee-badge label="Processing" variant="processing"></ee-badge>
+        <ee-badge label="Pending" variant="pending"></ee-badge>
+        <ee-badge label="Failed" variant="error"></ee-badge>
+      </div>
+    `,
+  }),
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/badge.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/badge.ts
@@ -1,0 +1,15 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type BadgeVariant = 'success' | 'processing' | 'pending' | 'error';
+
+@Component({
+  selector: 'ee-badge',
+  imports: [CommonModule],
+  templateUrl: './badge.html',
+  styleUrl: './badge.scss',
+})
+export class Badge {
+  label = input.required<string>();
+  variant = input<BadgeVariant>('pending');
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/badge/index.ts
@@ -1,0 +1,1 @@
+export * from './badge';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/button.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/button.html
@@ -1,0 +1,22 @@
+<button
+  class="button"
+  [class.button--primary]="variant() === 'primary'"
+  [class.button--secondary]="variant() === 'secondary'"
+  [class.button--danger]="variant() === 'danger'"
+  [class.button--disabled]="disabled()"
+  [class.button--full-width]="fullWidth()"
+  [class.button--icon-end]="iconPosition() === 'end'"
+  [disabled]="disabled()"
+  [type]="type()"
+  (click)="onClick()"
+>
+  @if (icon() && iconPosition() === 'start') {
+    <span class="material-icons button__icon">{{ icon() }}</span>
+  }
+  <span class="button__content">
+    <ng-content></ng-content>
+  </span>
+  @if (icon() && iconPosition() === 'end') {
+    <span class="material-icons button__icon">{{ icon() }}</span>
+  }
+</button>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/button.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/button.scss
@@ -1,0 +1,72 @@
+@use '../styles/variables';
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ee-spacing-sm);
+  padding: var(--ee-spacing-md) var(--ee-spacing-xl);
+  border-radius: var(--ee-radius-md);
+  font-size: var(--ee-font-size-base);
+  font-weight: 500;
+  font-family: var(--ee-font-family);
+  cursor: pointer;
+  transition: all var(--ee-transition-base);
+  border: none;
+  white-space: nowrap;
+
+  &--primary {
+    background: var(--ee-primary);
+    color: #121212;
+
+    &:hover:not(.button--disabled) {
+      background: var(--ee-primary-lighter);
+    }
+  }
+
+  &--secondary {
+    background: var(--ee-surface-elevated);
+    border: 1px solid var(--ee-divider);
+    color: var(--ee-on-surface);
+
+    &:hover:not(.button--disabled) {
+      background: var(--ee-surface-high);
+    }
+  }
+
+  &--danger {
+    background: var(--ee-warn);
+    color: #fff;
+
+    &:hover:not(.button--disabled) {
+      background: #e53935;
+    }
+  }
+
+  &--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &--full-width {
+    width: 100%;
+  }
+
+  &--icon-end {
+    flex-direction: row;
+  }
+
+  &:focus {
+    outline: 2px solid var(--ee-primary);
+    outline-offset: 2px;
+  }
+
+  &__icon {
+    font-size: 20px;
+  }
+
+  &__content {
+    display: inline-flex;
+    align-items: center;
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/button.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/button.spec.ts
@@ -1,0 +1,121 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Button } from './button';
+
+describe('Button', () => {
+  let component: Button;
+  let fixture: ComponentFixture<Button>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Button],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Button);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should apply primary variant by default', () => {
+    fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('button--primary')).toBe(true);
+  });
+
+  it('should apply secondary variant', () => {
+    fixture.componentRef.setInput('variant', 'secondary');
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('button--secondary')).toBe(true);
+  });
+
+  it('should apply danger variant', () => {
+    fixture.componentRef.setInput('variant', 'danger');
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('button--danger')).toBe(true);
+  });
+
+  it('should emit clicked event when clicked', () => {
+    const clickSpy = vi.fn();
+    component.clicked.subscribe(clickSpy);
+
+    fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('should not emit clicked when disabled', () => {
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+
+    const clickSpy = vi.fn();
+    component.clicked.subscribe(clickSpy);
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('should display icon when provided', () => {
+    fixture.componentRef.setInput('icon', 'add');
+    fixture.detectChanges();
+
+    const icon = fixture.nativeElement.querySelector('.material-icons');
+    expect(icon).toBeTruthy();
+    expect(icon.textContent.trim()).toBe('add');
+  });
+
+  it('should apply full-width class when fullWidth is true', () => {
+    fixture.componentRef.setInput('fullWidth', true);
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('button--full-width')).toBe(true);
+  });
+
+  it('should set button type', () => {
+    fixture.componentRef.setInput('type', 'submit');
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.type).toBe('submit');
+  });
+
+  it('should apply disabled class and attribute when disabled', () => {
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('button--disabled')).toBe(true);
+    expect(button.disabled).toBe(true);
+  });
+
+  it('should show icon at start position by default', () => {
+    fixture.componentRef.setInput('icon', 'add');
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    const icon = button.querySelector('.material-icons');
+    const content = button.querySelector('.button__content');
+
+    expect(button.firstElementChild).toBe(icon);
+  });
+
+  it('should show icon at end position when specified', () => {
+    fixture.componentRef.setInput('icon', 'arrow_forward');
+    fixture.componentRef.setInput('iconPosition', 'end');
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('button--icon-end')).toBe(true);
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/button.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/button.stories.ts
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { Button } from './button';
+
+const meta: Meta<Button> = {
+  title: 'Components/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'danger'],
+      description: 'Button style variant',
+    },
+    icon: {
+      control: 'text',
+      description: 'Material icon name',
+    },
+    iconPosition: {
+      control: 'select',
+      options: ['start', 'end'],
+      description: 'Position of the icon',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the button is disabled',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Whether the button takes full width',
+    },
+  },
+  render: (args) => ({
+    props: args,
+    template: `<ee-button
+      [variant]="variant"
+      [icon]="icon"
+      [iconPosition]="iconPosition"
+      [disabled]="disabled"
+      [fullWidth]="fullWidth"
+    >Button Text</ee-button>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<Button>;
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+  },
+  render: (args) => ({
+    props: args,
+    template: `<ee-button [variant]="variant">New Composition</ee-button>`,
+  }),
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+  },
+  render: (args) => ({
+    props: args,
+    template: `<ee-button [variant]="variant">Cancel</ee-button>`,
+  }),
+};
+
+export const Danger: Story = {
+  args: {
+    variant: 'danger',
+  },
+  render: (args) => ({
+    props: args,
+    template: `<ee-button [variant]="variant">Delete</ee-button>`,
+  }),
+};
+
+export const WithIconStart: Story = {
+  args: {
+    variant: 'primary',
+    icon: 'add_circle_outline',
+    iconPosition: 'start',
+  },
+  render: (args) => ({
+    props: args,
+    template: `<ee-button [variant]="variant" [icon]="icon" [iconPosition]="iconPosition">New Composition</ee-button>`,
+  }),
+};
+
+export const WithIconEnd: Story = {
+  args: {
+    variant: 'primary',
+    icon: 'arrow_forward',
+    iconPosition: 'end',
+  },
+  render: (args) => ({
+    props: args,
+    template: `<ee-button [variant]="variant" [icon]="icon" [iconPosition]="iconPosition">Next Step</ee-button>`,
+  }),
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: 'primary',
+    disabled: true,
+  },
+  render: (args) => ({
+    props: args,
+    template: `<ee-button [variant]="variant" [disabled]="disabled">Disabled Button</ee-button>`,
+  }),
+};
+
+export const FullWidth: Story = {
+  args: {
+    variant: 'primary',
+    fullWidth: true,
+    icon: 'add',
+  },
+  render: (args) => ({
+    props: args,
+    template: `<ee-button [variant]="variant" [fullWidth]="fullWidth" [icon]="icon">Full Width Button</ee-button>`,
+  }),
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/button.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/button.ts
@@ -1,0 +1,27 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'danger';
+
+@Component({
+  selector: 'ee-button',
+  imports: [CommonModule],
+  templateUrl: './button.html',
+  styleUrl: './button.scss',
+})
+export class Button {
+  variant = input<ButtonVariant>('primary');
+  icon = input<string>('');
+  iconPosition = input<'start' | 'end'>('start');
+  disabled = input<boolean>(false);
+  fullWidth = input<boolean>(false);
+  type = input<'button' | 'submit' | 'reset'>('button');
+
+  clicked = output<void>();
+
+  onClick(): void {
+    if (!this.disabled()) {
+      this.clicked.emit();
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/button/index.ts
@@ -1,0 +1,1 @@
+export * from './button';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/config-card.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/config-card.html
@@ -1,0 +1,47 @@
+<div class="config-card" (click)="onCardClick()">
+  <div class="config-card__icon">
+    <span class="material-icons">{{ icon() }}</span>
+  </div>
+
+  <div class="config-card__header">
+    <div class="config-card__header-left">
+      <div class="config-card__name">{{ name() }}</div>
+      @if (lastUsed()) {
+        <div class="config-card__last-used">
+          <span class="material-icons">access_time</span>
+          {{ lastUsed() }}
+        </div>
+      }
+    </div>
+    <button
+      class="config-card__menu"
+      (click)="onMenuClick($event)"
+      aria-label="More options"
+    >
+      <span class="material-icons">more_vert</span>
+    </button>
+  </div>
+
+  @if (description()) {
+    <div class="config-card__description">{{ description() }}</div>
+  }
+
+  @if (meta().length > 0) {
+    <div class="config-card__meta">
+      @for (item of meta(); track item.label) {
+        <div class="config-card__meta-item">
+          <span class="material-icons">{{ item.icon }}</span>
+          {{ item.label }}
+        </div>
+      }
+    </div>
+  }
+
+  @if (tags().length > 0) {
+    <div class="config-card__tags">
+      @for (tag of tags(); track tag.label) {
+        <ee-tag [label]="tag.label" [variant]="tag.variant || 'default'"></ee-tag>
+      }
+    </div>
+  }
+</div>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/config-card.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/config-card.scss
@@ -1,0 +1,116 @@
+@use '../styles/variables';
+
+.config-card {
+  background: var(--ee-surface);
+  border: 1px solid var(--ee-divider);
+  border-radius: var(--ee-radius-lg);
+  padding: 20px;
+  cursor: pointer;
+  transition: all var(--ee-transition-base);
+
+  &:hover {
+    border-color: var(--ee-primary);
+    transform: translateY(-2px);
+  }
+
+  &__icon {
+    width: 48px;
+    height: 48px;
+    background: var(--ee-surface-elevated);
+    border-radius: var(--ee-radius-lg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: var(--ee-spacing-md);
+
+    .material-icons {
+      font-size: 28px;
+      color: var(--ee-primary);
+    }
+  }
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: var(--ee-spacing-md);
+  }
+
+  &__header-left {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__name {
+    font-size: var(--ee-font-size-lg);
+    font-weight: 500;
+    margin-bottom: var(--ee-spacing-sm);
+    color: var(--ee-on-surface);
+  }
+
+  &__last-used {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--ee-spacing-xs);
+    font-size: var(--ee-font-size-xs);
+    padding: 3px var(--ee-spacing-sm);
+    border-radius: var(--ee-radius-sm);
+    background: rgba(129, 199, 132, 0.2);
+    color: var(--ee-success);
+
+    .material-icons {
+      font-size: 12px;
+    }
+  }
+
+  &__menu {
+    background: none;
+    border: none;
+    color: var(--ee-on-surface-medium);
+    cursor: pointer;
+    padding: var(--ee-spacing-xs);
+    margin: -4px -4px 0 0;
+
+    &:hover {
+      color: var(--ee-on-surface);
+    }
+  }
+
+  &__description {
+    font-size: var(--ee-font-size-md);
+    color: var(--ee-on-surface-medium);
+    margin-bottom: var(--ee-spacing-lg);
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  &__meta {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ee-spacing-sm);
+    padding-top: var(--ee-spacing-lg);
+    border-top: 1px solid var(--ee-divider);
+  }
+
+  &__meta-item {
+    display: flex;
+    align-items: center;
+    gap: var(--ee-spacing-sm);
+    font-size: var(--ee-font-size-sm);
+    color: var(--ee-on-surface-medium);
+
+    .material-icons {
+      font-size: 16px;
+    }
+  }
+
+  &__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: var(--ee-spacing-md);
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/config-card.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/config-card.spec.ts
@@ -1,0 +1,121 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ConfigCard } from './config-card';
+
+describe('ConfigCard', () => {
+  let component: ConfigCard;
+  let fixture: ComponentFixture<ConfigCard>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConfigCard],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConfigCard);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('name', 'E-Commerce API');
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the name', () => {
+    fixture.detectChanges();
+    const nameElement = fixture.nativeElement.querySelector(
+      '.config-card__name'
+    );
+    expect(nameElement.textContent.trim()).toBe('E-Commerce API');
+  });
+
+  it('should display the description when provided', () => {
+    fixture.componentRef.setInput(
+      'description',
+      'Complete e-commerce solution'
+    );
+    fixture.detectChanges();
+
+    const descriptionElement = fixture.nativeElement.querySelector(
+      '.config-card__description'
+    );
+    expect(descriptionElement.textContent.trim()).toBe(
+      'Complete e-commerce solution'
+    );
+  });
+
+  it('should display the default icon', () => {
+    fixture.detectChanges();
+    const iconElement = fixture.nativeElement.querySelector(
+      '.config-card__icon .material-icons'
+    );
+    expect(iconElement.textContent.trim()).toBe('layers');
+  });
+
+  it('should display custom icon', () => {
+    fixture.componentRef.setInput('icon', 'code');
+    fixture.detectChanges();
+
+    const iconElement = fixture.nativeElement.querySelector(
+      '.config-card__icon .material-icons'
+    );
+    expect(iconElement.textContent.trim()).toBe('code');
+  });
+
+  it('should display last used time when provided', () => {
+    fixture.componentRef.setInput('lastUsed', 'Used 2 hours ago');
+    fixture.detectChanges();
+
+    const lastUsedElement = fixture.nativeElement.querySelector(
+      '.config-card__last-used'
+    );
+    expect(lastUsedElement.textContent.trim()).toContain('Used 2 hours ago');
+  });
+
+  it('should render meta items', () => {
+    fixture.componentRef.setInput('meta', [
+      { icon: 'storage', label: '3 repositories' },
+      { icon: 'folder', label: '12 components' },
+    ]);
+    fixture.detectChanges();
+
+    const metaItems = fixture.nativeElement.querySelectorAll(
+      '.config-card__meta-item'
+    );
+    expect(metaItems.length).toBe(2);
+  });
+
+  it('should render tags', () => {
+    fixture.componentRef.setInput('tags', [
+      { label: 'GitHub', variant: 'github' },
+      { label: '.NET 8' },
+    ]);
+    fixture.detectChanges();
+
+    const tags = fixture.nativeElement.querySelectorAll('ee-tag');
+    expect(tags.length).toBe(2);
+  });
+
+  it('should emit cardClicked when card is clicked', () => {
+    fixture.detectChanges();
+    const clickSpy = vi.fn();
+    component.cardClicked.subscribe(clickSpy);
+
+    const card = fixture.nativeElement.querySelector('.config-card');
+    card.click();
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('should emit menuClicked when menu button is clicked', () => {
+    fixture.detectChanges();
+    const menuSpy = vi.fn();
+    component.menuClicked.subscribe(menuSpy);
+
+    const menuButton = fixture.nativeElement.querySelector(
+      '.config-card__menu'
+    );
+    menuButton.click();
+
+    expect(menuSpy).toHaveBeenCalled();
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/config-card.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/config-card.stories.ts
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { ConfigCard } from './config-card';
+
+const meta: Meta<ConfigCard> = {
+  title: 'Components/ConfigCard',
+  component: ConfigCard,
+  tags: ['autodocs'],
+  argTypes: {
+    name: {
+      control: 'text',
+      description: 'Configuration name',
+    },
+    description: {
+      control: 'text',
+      description: 'Configuration description',
+    },
+    icon: {
+      control: 'text',
+      description: 'Material icon name',
+    },
+    lastUsed: {
+      control: 'text',
+      description: 'Last used timestamp',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<ConfigCard>;
+
+export const ECommerceAPI: Story = {
+  args: {
+    name: 'E-Commerce API',
+    description:
+      'Complete e-commerce solution with authentication, product catalog, shopping cart, and order management',
+    icon: 'layers',
+    lastUsed: 'Used 2 hours ago',
+    meta: [
+      { icon: 'storage', label: '3 repositories' },
+      { icon: 'folder', label: '12 components' },
+      { icon: 'schedule', label: 'Updated 2 days ago' },
+    ],
+    tags: [
+      { label: 'GitHub', variant: 'github' },
+      { label: 'Local', variant: 'local' },
+      { label: '.NET 8' },
+    ],
+  },
+};
+
+export const MicroservicesTemplate: Story = {
+  args: {
+    name: 'Microservices Template',
+    description:
+      'Multi-service architecture with API gateway, message bus, and shared libraries',
+    icon: 'layers',
+    meta: [
+      { icon: 'storage', label: '5 repositories' },
+      { icon: 'folder', label: '24 components' },
+      { icon: 'schedule', label: 'Updated 5 days ago' },
+    ],
+    tags: [
+      { label: 'GitHub', variant: 'github' },
+      { label: '.NET 8' },
+      { label: 'Docker' },
+    ],
+  },
+};
+
+export const MinimalCard: Story = {
+  args: {
+    name: 'Minimal API Starter',
+    description: 'Lightweight API template with essential features',
+  },
+};
+
+export const CardWithCustomIcon: Story = {
+  args: {
+    name: 'Authentication Module',
+    description: 'JWT-based authentication with user management',
+    icon: 'lock',
+    tags: [
+      { label: 'Local', variant: 'local' },
+      { label: '.NET 8' },
+    ],
+  },
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/config-card.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/config-card.ts
@@ -1,0 +1,40 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Tag } from '../tag';
+
+export interface ConfigCardMeta {
+  icon: string;
+  label: string;
+}
+
+export interface ConfigCardTag {
+  label: string;
+  variant?: 'default' | 'github' | 'local' | 'primary';
+}
+
+@Component({
+  selector: 'ee-config-card',
+  imports: [CommonModule, Tag],
+  templateUrl: './config-card.html',
+  styleUrl: './config-card.scss',
+})
+export class ConfigCard {
+  name = input.required<string>();
+  description = input<string>('');
+  icon = input<string>('layers');
+  lastUsed = input<string>('');
+  meta = input<ConfigCardMeta[]>([]);
+  tags = input<ConfigCardTag[]>([]);
+
+  cardClicked = output<void>();
+  menuClicked = output<void>();
+
+  onCardClick(): void {
+    this.cardClicked.emit();
+  }
+
+  onMenuClick(event: Event): void {
+    event.stopPropagation();
+    this.menuClicked.emit();
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/config-card/index.ts
@@ -1,0 +1,1 @@
+export * from './config-card';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/dialog.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/dialog.html
@@ -1,0 +1,29 @@
+@if (open()) {
+  <div class="dialog-overlay" (click)="onOverlayClick($event)">
+    <div class="dialog" role="dialog" aria-modal="true">
+      <div class="dialog__header">
+        <div class="dialog__title">
+          @if (icon()) {
+            <span class="material-icons dialog__title-icon">{{ icon() }}</span>
+          }
+          {{ title() }}
+        </div>
+        @if (showCloseButton()) {
+          <ee-icon-button
+            icon="close"
+            ariaLabel="Close dialog"
+            (clicked)="onClose()"
+          ></ee-icon-button>
+        }
+      </div>
+
+      <div class="dialog__content">
+        <ng-content></ng-content>
+      </div>
+
+      <div class="dialog__actions">
+        <ng-content select="[actions]"></ng-content>
+      </div>
+    </div>
+  </div>
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/dialog.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/dialog.scss
@@ -1,0 +1,82 @@
+@use '../styles/variables';
+
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--ee-spacing-lg);
+}
+
+.dialog {
+  background: var(--ee-surface-elevated);
+  border-radius: var(--ee-radius-lg);
+  width: 100%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--ee-shadow-lg);
+
+  &__header {
+    padding: 20px var(--ee-spacing-xl);
+    border-bottom: 1px solid var(--ee-divider);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__title {
+    font-size: var(--ee-font-size-xxl);
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: var(--ee-spacing-md);
+    color: var(--ee-on-surface);
+  }
+
+  &__title-icon {
+    color: var(--ee-primary);
+  }
+
+  &__content {
+    padding: var(--ee-spacing-xl);
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  &__actions {
+    padding: var(--ee-spacing-lg) var(--ee-spacing-xl);
+    border-top: 1px solid var(--ee-divider);
+    display: flex;
+    gap: var(--ee-spacing-md);
+    justify-content: flex-end;
+
+    &:empty {
+      display: none;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .dialog {
+    max-width: 100%;
+    max-height: 100%;
+    border-radius: 0;
+  }
+
+  .dialog__actions {
+    flex-direction: column-reverse;
+
+    ::ng-deep .button {
+      width: 100%;
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/dialog.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/dialog.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Dialog } from './dialog';
+
+describe('Dialog', () => {
+  let component: Dialog;
+  let fixture: ComponentFixture<Dialog>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Dialog],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Dialog);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('title', 'Test Dialog');
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the title', () => {
+    fixture.detectChanges();
+    const titleElement = fixture.nativeElement.querySelector('.dialog__title');
+    expect(titleElement.textContent.trim()).toBe('Test Dialog');
+  });
+
+  it('should show dialog when open is true', () => {
+    fixture.componentRef.setInput('open', true);
+    fixture.detectChanges();
+
+    const dialogOverlay =
+      fixture.nativeElement.querySelector('.dialog-overlay');
+    expect(dialogOverlay).toBeTruthy();
+  });
+
+  it('should hide dialog when open is false', () => {
+    fixture.componentRef.setInput('open', false);
+    fixture.detectChanges();
+
+    const dialogOverlay =
+      fixture.nativeElement.querySelector('.dialog-overlay');
+    expect(dialogOverlay).toBeFalsy();
+  });
+
+  it('should display icon when provided', () => {
+    fixture.componentRef.setInput('icon', 'save');
+    fixture.detectChanges();
+
+    const iconElement = fixture.nativeElement.querySelector(
+      '.dialog__title-icon'
+    );
+    expect(iconElement.textContent.trim()).toBe('save');
+  });
+
+  it('should show close button by default', () => {
+    fixture.detectChanges();
+    const closeButton = fixture.nativeElement.querySelector('ee-icon-button');
+    expect(closeButton).toBeTruthy();
+  });
+
+  it('should hide close button when showCloseButton is false', () => {
+    fixture.componentRef.setInput('showCloseButton', false);
+    fixture.detectChanges();
+
+    const closeButton = fixture.nativeElement.querySelector('ee-icon-button');
+    expect(closeButton).toBeFalsy();
+  });
+
+  it('should emit closed event when close button is clicked', () => {
+    fixture.detectChanges();
+    const closeSpy = vi.fn();
+    component.closed.subscribe(closeSpy);
+
+    const closeButton = fixture.nativeElement.querySelector('ee-icon-button');
+    closeButton.dispatchEvent(new CustomEvent('clicked'));
+
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('should emit closed event when overlay is clicked', () => {
+    fixture.detectChanges();
+    const closeSpy = vi.fn();
+    component.closed.subscribe(closeSpy);
+
+    const overlay = fixture.nativeElement.querySelector('.dialog-overlay');
+    overlay.click();
+
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('should not emit closed when dialog content is clicked', () => {
+    fixture.detectChanges();
+    const closeSpy = vi.fn();
+    component.closed.subscribe(closeSpy);
+
+    const dialog = fixture.nativeElement.querySelector('.dialog');
+    dialog.click();
+
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/dialog.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/dialog.stories.ts
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { Dialog } from './dialog';
+import { Button } from '../button';
+
+const meta: Meta<Dialog> = {
+  title: 'Components/Dialog',
+  component: Dialog,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({
+      imports: [Button],
+    }),
+  ],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Dialog title',
+    },
+    icon: {
+      control: 'text',
+      description: 'Material icon name',
+    },
+    showCloseButton: {
+      control: 'boolean',
+      description: 'Show close button',
+    },
+    open: {
+      control: 'boolean',
+      description: 'Whether dialog is open',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<Dialog>;
+
+export const SaveConfiguration: Story = {
+  args: {
+    title: 'Save Repository Configuration',
+    icon: 'save',
+    showCloseButton: true,
+    open: true,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <ee-dialog [title]="title" [icon]="icon" [showCloseButton]="showCloseButton" [open]="open">
+        <div style="color: #e6edf3;">
+          <p style="margin-bottom: 16px;">Enter a name for this configuration.</p>
+          <input type="text" placeholder="Configuration name" style="width: 100%; padding: 12px; background: #161b22; border: 1px solid rgba(230,237,243,0.12); border-radius: 8px; color: #e6edf3;" />
+        </div>
+        <div actions>
+          <ee-button variant="secondary">Cancel</ee-button>
+          <ee-button icon="save">Save Configuration</ee-button>
+        </div>
+      </ee-dialog>
+    `,
+  }),
+};
+
+export const ConfirmDelete: Story = {
+  args: {
+    title: 'Delete Request?',
+    icon: 'warning',
+    showCloseButton: false,
+    open: true,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <ee-dialog [title]="title" [icon]="icon" [showCloseButton]="showCloseButton" [open]="open">
+        <div style="color: #e6edf3;">
+          <p>Are you sure you want to delete this request? This action cannot be undone.</p>
+        </div>
+        <div actions>
+          <ee-button variant="secondary">Cancel</ee-button>
+          <ee-button variant="danger" icon="delete_forever">Delete</ee-button>
+        </div>
+      </ee-dialog>
+    `,
+  }),
+};
+
+export const SimpleDialog: Story = {
+  args: {
+    title: 'Information',
+    open: true,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <ee-dialog [title]="title" [open]="open">
+        <div style="color: #e6edf3;">
+          <p>This is a simple dialog with just content.</p>
+        </div>
+        <div actions>
+          <ee-button>OK</ee-button>
+        </div>
+      </ee-dialog>
+    `,
+  }),
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/dialog.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/dialog.ts
@@ -1,0 +1,28 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IconButton } from '../icon-button';
+
+@Component({
+  selector: 'ee-dialog',
+  imports: [CommonModule, IconButton],
+  templateUrl: './dialog.html',
+  styleUrl: './dialog.scss',
+})
+export class Dialog {
+  title = input.required<string>();
+  icon = input<string>('');
+  showCloseButton = input<boolean>(true);
+  open = input<boolean>(true);
+
+  closed = output<void>();
+
+  onClose(): void {
+    this.closed.emit();
+  }
+
+  onOverlayClick(event: Event): void {
+    if (event.target === event.currentTarget) {
+      this.onClose();
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/dialog/index.ts
@@ -1,0 +1,1 @@
+export * from './dialog';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/empty-state.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/empty-state.html
@@ -1,0 +1,15 @@
+<div class="empty-state">
+  <div class="empty-state__icon">
+    <span class="material-icons">{{ icon() }}</span>
+  </div>
+  <h1 class="empty-state__title">{{ title() }}</h1>
+  @if (description()) {
+    <p class="empty-state__description">{{ description() }}</p>
+  }
+  <div class="empty-state__actions">
+    <ng-content select="[actions]"></ng-content>
+  </div>
+  <div class="empty-state__quick-start">
+    <ng-content select="[quickStart]"></ng-content>
+  </div>
+</div>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/empty-state.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/empty-state.scss
@@ -1,0 +1,57 @@
+@use '../styles/variables';
+
+.empty-state {
+  text-align: center;
+  padding: 48px var(--ee-spacing-xl);
+  max-width: 480px;
+  margin: 0 auto;
+
+  &__icon {
+    width: 120px;
+    height: 120px;
+    margin: 0 auto var(--ee-spacing-xl);
+    background: var(--ee-surface-elevated);
+    border-radius: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px dashed var(--ee-divider);
+
+    .material-icons {
+      font-size: 64px;
+      color: var(--ee-on-surface-disabled);
+    }
+  }
+
+  &__title {
+    font-size: var(--ee-font-size-title);
+    font-weight: 500;
+    margin-bottom: var(--ee-spacing-md);
+    color: var(--ee-on-surface);
+  }
+
+  &__description {
+    font-size: var(--ee-font-size-base);
+    color: var(--ee-on-surface-medium);
+    line-height: 1.6;
+    margin-bottom: var(--ee-spacing-xxl);
+  }
+
+  &__actions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ee-spacing-md);
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  &__quick-start {
+    margin-top: 48px;
+
+    &:empty {
+      display: none;
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/empty-state.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/empty-state.spec.ts
@@ -1,0 +1,87 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EmptyState } from './empty-state';
+
+describe('EmptyState', () => {
+  let component: EmptyState;
+  let fixture: ComponentFixture<EmptyState>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EmptyState],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmptyState);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('title', 'Test Empty State');
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the title', () => {
+    fixture.detectChanges();
+    const titleElement = fixture.nativeElement.querySelector(
+      '.empty-state__title'
+    );
+    expect(titleElement.textContent.trim()).toBe('Test Empty State');
+  });
+
+  it('should display the description when provided', () => {
+    fixture.componentRef.setInput(
+      'description',
+      'This is a test description.'
+    );
+    fixture.detectChanges();
+
+    const descriptionElement = fixture.nativeElement.querySelector(
+      '.empty-state__description'
+    );
+    expect(descriptionElement.textContent.trim()).toBe(
+      'This is a test description.'
+    );
+  });
+
+  it('should not display description when not provided', () => {
+    fixture.detectChanges();
+    const descriptionElement = fixture.nativeElement.querySelector(
+      '.empty-state__description'
+    );
+    expect(descriptionElement).toBeFalsy();
+  });
+
+  it('should display the default icon', () => {
+    fixture.detectChanges();
+    const iconElement = fixture.nativeElement.querySelector(
+      '.empty-state__icon .material-icons'
+    );
+    expect(iconElement.textContent.trim()).toBe('layers');
+  });
+
+  it('should display a custom icon when provided', () => {
+    fixture.componentRef.setInput('icon', 'folder');
+    fixture.detectChanges();
+
+    const iconElement = fixture.nativeElement.querySelector(
+      '.empty-state__icon .material-icons'
+    );
+    expect(iconElement.textContent.trim()).toBe('folder');
+  });
+
+  it('should have actions slot', () => {
+    fixture.detectChanges();
+    const actionsElement = fixture.nativeElement.querySelector(
+      '.empty-state__actions'
+    );
+    expect(actionsElement).toBeTruthy();
+  });
+
+  it('should have quick-start slot', () => {
+    fixture.detectChanges();
+    const quickStartElement = fixture.nativeElement.querySelector(
+      '.empty-state__quick-start'
+    );
+    expect(quickStartElement).toBeTruthy();
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/empty-state.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/empty-state.stories.ts
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { EmptyState } from './empty-state';
+import { Button } from '../button';
+
+const meta: Meta<EmptyState> = {
+  title: 'Components/EmptyState',
+  component: EmptyState,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({
+      imports: [Button],
+    }),
+  ],
+  argTypes: {
+    icon: {
+      control: 'text',
+      description: 'Material icon name',
+    },
+    title: {
+      control: 'text',
+      description: 'Main title text',
+    },
+    description: {
+      control: 'text',
+      description: 'Description text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<EmptyState>;
+
+export const Default: Story = {
+  args: {
+    icon: 'layers',
+    title: 'Start Composing Your Solution',
+    description:
+      'Create a custom solution by selecting components from repositories, local folders, or templates. Build exactly what you need with drag-and-drop simplicity.',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <ee-empty-state [icon]="icon" [title]="title" [description]="description">
+        <div actions>
+          <ee-button icon="add_circle_outline">New Composition</ee-button>
+          <ee-button variant="secondary" icon="folder_open">Load Saved Configuration</ee-button>
+        </div>
+      </ee-empty-state>
+    `,
+  }),
+};
+
+export const NoResults: Story = {
+  args: {
+    icon: 'search_off',
+    title: 'No Results Found',
+    description: 'Try adjusting your search or filter criteria.',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <ee-empty-state [icon]="icon" [title]="title" [description]="description">
+        <div actions>
+          <ee-button variant="secondary">Clear Filters</ee-button>
+        </div>
+      </ee-empty-state>
+    `,
+  }),
+};
+
+export const EmptyFolder: Story = {
+  args: {
+    icon: 'folder_open',
+    title: 'This Folder is Empty',
+    description: 'Add files or folders to get started.',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    icon: 'error_outline',
+    title: 'Something Went Wrong',
+    description:
+      'We encountered an error while loading your data. Please try again.',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <ee-empty-state [icon]="icon" [title]="title" [description]="description">
+        <div actions>
+          <ee-button icon="refresh">Retry</ee-button>
+        </div>
+      </ee-empty-state>
+    `,
+  }),
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/empty-state.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/empty-state.ts
@@ -1,0 +1,14 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'ee-empty-state',
+  imports: [CommonModule],
+  templateUrl: './empty-state.html',
+  styleUrl: './empty-state.scss',
+})
+export class EmptyState {
+  icon = input<string>('layers');
+  title = input.required<string>();
+  description = input<string>('');
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/empty-state/index.ts
@@ -1,0 +1,1 @@
+export * from './empty-state';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/form-section.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/form-section.html
@@ -1,0 +1,8 @@
+<div class="form-section">
+  @if (title()) {
+    <h2 class="form-section__title">{{ title() }}</h2>
+  }
+  <div class="form-section__content">
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/form-section.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/form-section.scss
@@ -1,0 +1,22 @@
+@use '../styles/variables';
+
+.form-section {
+  background: var(--ee-surface);
+  border: 1px solid var(--ee-divider);
+  border-radius: var(--ee-radius-lg);
+  padding: var(--ee-spacing-xl);
+  margin-bottom: var(--ee-spacing-xl);
+
+  &__title {
+    font-size: var(--ee-font-size-xl);
+    font-weight: 500;
+    margin-bottom: var(--ee-spacing-lg);
+    color: var(--ee-on-surface);
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ee-spacing-lg);
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/form-section.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/form-section.spec.ts
@@ -1,0 +1,47 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormSection } from './form-section';
+
+describe('FormSection', () => {
+  let component: FormSection;
+  let fixture: ComponentFixture<FormSection>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormSection],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FormSection);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the title when provided', () => {
+    fixture.componentRef.setInput('title', 'Project Information');
+    fixture.detectChanges();
+
+    const titleElement = fixture.nativeElement.querySelector(
+      '.form-section__title'
+    );
+    expect(titleElement.textContent.trim()).toBe('Project Information');
+  });
+
+  it('should not display title when not provided', () => {
+    fixture.detectChanges();
+    const titleElement = fixture.nativeElement.querySelector(
+      '.form-section__title'
+    );
+    expect(titleElement).toBeFalsy();
+  });
+
+  it('should have content area for child elements', () => {
+    fixture.detectChanges();
+    const contentElement = fixture.nativeElement.querySelector(
+      '.form-section__content'
+    );
+    expect(contentElement).toBeTruthy();
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/form-section.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/form-section.stories.ts
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { FormSection } from './form-section';
+
+const meta: Meta<FormSection> = {
+  title: 'Components/FormSection',
+  component: FormSection,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Section title',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<FormSection>;
+
+export const WithTitle: Story = {
+  args: {
+    title: 'Project Information',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <ee-form-section [title]="title">
+        <div style="color: #e6edf3;">
+          <p style="margin-bottom: 12px;">Form content goes here</p>
+          <input type="text" placeholder="Example input" style="width: 100%; padding: 10px; background: #21262d; border: 1px solid rgba(230,237,243,0.12); border-radius: 6px; color: #e6edf3;" />
+        </div>
+      </ee-form-section>
+    `,
+  }),
+};
+
+export const WithoutTitle: Story = {
+  args: {
+    title: '',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <ee-form-section [title]="title">
+        <div style="color: #e6edf3;">
+          <p>Section without a title</p>
+        </div>
+      </ee-form-section>
+    `,
+  }),
+};
+
+export const TargetFramework: Story = {
+  args: {
+    title: 'Target Framework',
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <ee-form-section [title]="title">
+        <div style="display: flex; flex-direction: column; gap: 8px;">
+          <div style="display: flex; align-items: center; gap: 12px; padding: 12px; background: rgba(159, 168, 218, 0.08); border: 1px solid #9fa8da; border-radius: 8px; color: #e6edf3;">
+            <span style="color: #9fa8da;">●</span> .NET 8 (Recommended)
+          </div>
+          <div style="display: flex; align-items: center; gap: 12px; padding: 12px; background: #21262d; border: 1px solid rgba(230,237,243,0.12); border-radius: 8px; color: #e6edf3;">
+            <span style="color: rgba(230,237,243,0.38);">○</span> .NET 7
+          </div>
+          <div style="display: flex; align-items: center; gap: 12px; padding: 12px; background: #21262d; border: 1px solid rgba(230,237,243,0.12); border-radius: 8px; color: #e6edf3;">
+            <span style="color: rgba(230,237,243,0.38);">○</span> .NET 6 (LTS)
+          </div>
+        </div>
+      </ee-form-section>
+    `,
+  }),
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/form-section.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/form-section.ts
@@ -1,0 +1,12 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'ee-form-section',
+  imports: [CommonModule],
+  templateUrl: './form-section.html',
+  styleUrl: './form-section.scss',
+})
+export class FormSection {
+  title = input<string>('');
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/form-section/index.ts
@@ -1,0 +1,1 @@
+export * from './form-section';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/icon-button.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/icon-button.html
@@ -1,0 +1,10 @@
+<button
+  class="icon-button"
+  [class.icon-button--back]="variant() === 'back'"
+  [class.icon-button--disabled]="disabled()"
+  [disabled]="disabled()"
+  [attr.aria-label]="ariaLabel() || icon()"
+  (click)="onClick()"
+>
+  <span class="material-icons">{{ icon() }}</span>
+</button>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/icon-button.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/icon-button.scss
@@ -1,0 +1,37 @@
+@use '../styles/variables';
+
+.icon-button {
+  background: none;
+  border: none;
+  color: var(--ee-on-surface-medium);
+  cursor: pointer;
+  padding: var(--ee-spacing-sm);
+  border-radius: var(--ee-radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--ee-transition-base);
+
+  &:hover:not(.icon-button--disabled) {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--ee-on-surface);
+  }
+
+  &:focus {
+    outline: 2px solid var(--ee-primary);
+    outline-offset: 2px;
+  }
+
+  &--back {
+    color: var(--ee-on-surface);
+  }
+
+  &--disabled {
+    color: var(--ee-on-surface-disabled);
+    cursor: not-allowed;
+  }
+
+  .material-icons {
+    font-size: 24px;
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/icon-button.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/icon-button.spec.ts
@@ -1,0 +1,83 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconButton } from './icon-button';
+
+describe('IconButton', () => {
+  let component: IconButton;
+  let fixture: ComponentFixture<IconButton>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [IconButton],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(IconButton);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('icon', 'arrow_back');
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the icon', () => {
+    fixture.detectChanges();
+    const iconElement = fixture.nativeElement.querySelector('.material-icons');
+    expect(iconElement.textContent.trim()).toBe('arrow_back');
+  });
+
+  it('should emit clicked event when clicked', () => {
+    const clickSpy = vi.fn();
+    component.clicked.subscribe(clickSpy);
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('should not emit clicked when disabled', () => {
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+
+    const clickSpy = vi.fn();
+    component.clicked.subscribe(clickSpy);
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('should apply back variant class', () => {
+    fixture.componentRef.setInput('variant', 'back');
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('icon-button--back')).toBe(true);
+  });
+
+  it('should apply disabled class when disabled', () => {
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.classList.contains('icon-button--disabled')).toBe(true);
+    expect(button.disabled).toBe(true);
+  });
+
+  it('should set aria-label from input', () => {
+    fixture.componentRef.setInput('ariaLabel', 'Go back');
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('aria-label')).toBe('Go back');
+  });
+
+  it('should use icon as aria-label fallback', () => {
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('aria-label')).toBe('arrow_back');
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/icon-button.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/icon-button.stories.ts
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { IconButton } from './icon-button';
+
+const meta: Meta<IconButton> = {
+  title: 'Components/IconButton',
+  component: IconButton,
+  tags: ['autodocs'],
+  argTypes: {
+    icon: {
+      control: 'text',
+      description: 'Material icon name',
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'back'],
+      description: 'Button variant style',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the button is disabled',
+    },
+    ariaLabel: {
+      control: 'text',
+      description: 'Accessibility label for the button',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<IconButton>;
+
+export const Default: Story = {
+  args: {
+    icon: 'more_vert',
+    variant: 'default',
+    disabled: false,
+  },
+};
+
+export const BackButton: Story = {
+  args: {
+    icon: 'arrow_back',
+    variant: 'back',
+    ariaLabel: 'Go back',
+  },
+};
+
+export const HelpButton: Story = {
+  args: {
+    icon: 'help_outline',
+    ariaLabel: 'Get help',
+  },
+};
+
+export const CloseButton: Story = {
+  args: {
+    icon: 'close',
+    ariaLabel: 'Close',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    icon: 'settings',
+    disabled: true,
+  },
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/icon-button.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/icon-button.ts
@@ -1,0 +1,25 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type IconButtonVariant = 'default' | 'back';
+
+@Component({
+  selector: 'ee-icon-button',
+  imports: [CommonModule],
+  templateUrl: './icon-button.html',
+  styleUrl: './icon-button.scss',
+})
+export class IconButton {
+  icon = input.required<string>();
+  variant = input<IconButtonVariant>('default');
+  disabled = input<boolean>(false);
+  ariaLabel = input<string>('');
+
+  clicked = output<void>();
+
+  onClick(): void {
+    if (!this.disabled()) {
+      this.clicked.emit();
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/icon-button/index.ts
@@ -1,0 +1,1 @@
+export * from './icon-button';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/index.ts
@@ -1,0 +1,1 @@
+export * from './log-output';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/log-output.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/log-output.html
@@ -1,0 +1,28 @@
+<div class="log-output">
+  @if (title()) {
+    <div class="log-output__header">
+      <span class="material-icons">terminal</span>
+      {{ title() }}
+    </div>
+  }
+  <div
+    #logContainer
+    class="log-output__container"
+    [style.maxHeight]="maxHeight()"
+  >
+    @for (log of logs(); track $index) {
+      <div
+        class="log-output__line"
+        [class.log-output__line--info]="log.level === 'info'"
+        [class.log-output__line--success]="log.level === 'success'"
+        [class.log-output__line--warning]="log.level === 'warning'"
+        [class.log-output__line--error]="log.level === 'error'"
+      >
+        {{ getLevelPrefix(log.level) }} {{ log.message }}
+      </div>
+    }
+    @if (logs().length === 0) {
+      <div class="log-output__empty">No log entries</div>
+    }
+  </div>
+</div>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/log-output.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/log-output.scss
@@ -1,0 +1,54 @@
+@use '../styles/variables';
+
+.log-output {
+  background: var(--ee-surface-elevated);
+  border-radius: var(--ee-radius-md);
+  overflow: hidden;
+
+  &__header {
+    font-size: var(--ee-font-size-xl);
+    font-weight: 500;
+    padding: var(--ee-spacing-xl);
+    display: flex;
+    align-items: center;
+    gap: var(--ee-spacing-sm);
+    color: var(--ee-on-surface);
+    border-bottom: 1px solid var(--ee-divider);
+  }
+
+  &__container {
+    background: #000;
+    padding: var(--ee-spacing-lg);
+    font-family: 'Courier New', monospace;
+    font-size: var(--ee-font-size-md);
+    overflow-y: auto;
+    color: #00ff00;
+  }
+
+  &__line {
+    margin-bottom: var(--ee-spacing-xs);
+    line-height: 1.4;
+    word-break: break-word;
+
+    &--info {
+      color: #0099ff;
+    }
+
+    &--success {
+      color: #00ff00;
+    }
+
+    &--warning {
+      color: #ffaa00;
+    }
+
+    &--error {
+      color: #ff3333;
+    }
+  }
+
+  &__empty {
+    color: var(--ee-on-surface-disabled);
+    font-style: italic;
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/log-output.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/log-output.spec.ts
@@ -1,0 +1,89 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LogOutput, LogEntry } from './log-output';
+
+describe('LogOutput', () => {
+  let component: LogOutput;
+  let fixture: ComponentFixture<LogOutput>;
+  const mockLogs: LogEntry[] = [
+    { level: 'info', message: 'Starting execution' },
+    { level: 'success', message: 'Repository cloned successfully' },
+    { level: 'warning', message: 'Missing optional dependency' },
+    { level: 'error', message: 'Failed to copy file' },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LogOutput],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LogOutput);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('logs', mockLogs);
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render all log entries', () => {
+    fixture.detectChanges();
+    const logLines = fixture.nativeElement.querySelectorAll('.log-output__line');
+    expect(logLines.length).toBe(4);
+  });
+
+  it('should display title when provided', () => {
+    fixture.componentRef.setInput('title', 'Execution Log');
+    fixture.detectChanges();
+
+    const header = fixture.nativeElement.querySelector('.log-output__header');
+    expect(header.textContent.trim()).toContain('Execution Log');
+  });
+
+  it('should apply correct class for info level', () => {
+    fixture.detectChanges();
+    const infoLine = fixture.nativeElement.querySelector('.log-output__line--info');
+    expect(infoLine).toBeTruthy();
+  });
+
+  it('should apply correct class for success level', () => {
+    fixture.detectChanges();
+    const successLine = fixture.nativeElement.querySelector('.log-output__line--success');
+    expect(successLine).toBeTruthy();
+  });
+
+  it('should apply correct class for warning level', () => {
+    fixture.detectChanges();
+    const warningLine = fixture.nativeElement.querySelector('.log-output__line--warning');
+    expect(warningLine).toBeTruthy();
+  });
+
+  it('should apply correct class for error level', () => {
+    fixture.detectChanges();
+    const errorLine = fixture.nativeElement.querySelector('.log-output__line--error');
+    expect(errorLine).toBeTruthy();
+  });
+
+  it('should return correct level prefix', () => {
+    expect(component.getLevelPrefix('info')).toBe('[INFO]');
+    expect(component.getLevelPrefix('success')).toBe('[SUCCESS]');
+    expect(component.getLevelPrefix('warning')).toBe('[WARNING]');
+    expect(component.getLevelPrefix('error')).toBe('[ERROR]');
+  });
+
+  it('should show empty message when no logs', () => {
+    fixture.componentRef.setInput('logs', []);
+    fixture.detectChanges();
+
+    const emptyMessage = fixture.nativeElement.querySelector('.log-output__empty');
+    expect(emptyMessage.textContent.trim()).toBe('No log entries');
+  });
+
+  it('should apply custom max height', () => {
+    fixture.componentRef.setInput('maxHeight', '200px');
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector('.log-output__container');
+    expect(container.style.maxHeight).toBe('200px');
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/log-output.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/log-output.stories.ts
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { LogOutput, LogEntry } from './log-output';
+
+const meta: Meta<LogOutput> = {
+  title: 'Components/LogOutput',
+  component: LogOutput,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Section title',
+    },
+    maxHeight: {
+      control: 'text',
+      description: 'Maximum height of log container',
+    },
+    autoScroll: {
+      control: 'boolean',
+      description: 'Auto scroll to bottom on new entries',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<LogOutput>;
+
+export const ExecutionLog: Story = {
+  args: {
+    title: 'Execution Log',
+    maxHeight: '300px',
+    logs: [
+      { level: 'info', message: "Starting execution for 'Enterprise API Platform'" },
+      { level: 'info', message: 'Output directory: /home/user/output/enterprise' },
+      { level: 'success', message: 'Cloning dotnet/aspnetcore from main branch' },
+      { level: 'success', message: 'Cloning dotnet/runtime from release/8.0 branch' },
+      { level: 'success', message: 'Cloning EntityFramework/EntityFramework from main branch' },
+      { level: 'success', message: 'Local directory validated: custom-middleware' },
+      { level: 'info', message: 'Validating configured folders...' },
+      { level: 'success', message: 'Validated: src/Mvc/Mvc.Core' },
+      { level: 'success', message: 'Validated: src/Http/Http.Abstractions' },
+      { level: 'info', message: 'Copying project folders to output directory...' },
+      { level: 'success', message: 'Copied src/Mvc/Mvc.Core (124 files)' },
+    ] as LogEntry[],
+  },
+};
+
+export const WithErrors: Story = {
+  args: {
+    title: 'Build Log',
+    logs: [
+      { level: 'info', message: 'Starting build process...' },
+      { level: 'success', message: 'Dependencies restored' },
+      { level: 'warning', message: 'Package version mismatch detected' },
+      { level: 'error', message: 'Build failed: Missing reference to System.Net.Http' },
+      { level: 'error', message: 'Error CS0246: The type or namespace name could not be found' },
+    ] as LogEntry[],
+  },
+};
+
+export const EmptyLog: Story = {
+  args: {
+    title: 'Activity Log',
+    logs: [] as LogEntry[],
+  },
+};
+
+export const NoTitle: Story = {
+  args: {
+    logs: [
+      { level: 'info', message: 'Processing...' },
+      { level: 'success', message: 'Done!' },
+    ] as LogEntry[],
+  },
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/log-output.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/log-output/log-output.ts
@@ -1,0 +1,50 @@
+import { Component, input, ElementRef, viewChild, effect } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type LogLevel = 'info' | 'success' | 'warning' | 'error';
+
+export interface LogEntry {
+  level: LogLevel;
+  message: string;
+  timestamp?: Date;
+}
+
+@Component({
+  selector: 'ee-log-output',
+  imports: [CommonModule],
+  templateUrl: './log-output.html',
+  styleUrl: './log-output.scss',
+})
+export class LogOutput {
+  logs = input.required<LogEntry[]>();
+  title = input<string>('');
+  maxHeight = input<string>('400px');
+  autoScroll = input<boolean>(true);
+
+  logContainer = viewChild<ElementRef>('logContainer');
+
+  constructor() {
+    effect(() => {
+      const logs = this.logs();
+      const container = this.logContainer();
+      if (this.autoScroll() && container && logs.length > 0) {
+        setTimeout(() => {
+          container.nativeElement.scrollTop = container.nativeElement.scrollHeight;
+        });
+      }
+    });
+  }
+
+  getLevelPrefix(level: LogLevel): string {
+    switch (level) {
+      case 'info':
+        return '[INFO]';
+      case 'success':
+        return '[SUCCESS]';
+      case 'warning':
+        return '[WARNING]';
+      case 'error':
+        return '[ERROR]';
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/index.ts
@@ -1,0 +1,1 @@
+export * from './page-header';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/page-header.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/page-header.html
@@ -1,0 +1,30 @@
+<header class="page-header">
+  <div class="page-header__left">
+    @if (showBackButton()) {
+      <ee-icon-button
+        icon="arrow_back"
+        variant="back"
+        ariaLabel="Go back"
+        (clicked)="onBackClick()"
+      ></ee-icon-button>
+    }
+    <span class="page-header__title">{{ title() }}</span>
+  </div>
+  <div class="page-header__actions">
+    <ng-content></ng-content>
+    @if (showHelpButton()) {
+      <ee-icon-button
+        icon="help_outline"
+        ariaLabel="Help"
+        (clicked)="onHelpClick()"
+      ></ee-icon-button>
+    }
+    @if (showMenuButton()) {
+      <ee-icon-button
+        icon="more_vert"
+        ariaLabel="More options"
+        (clicked)="onMenuClick()"
+      ></ee-icon-button>
+    }
+  </div>
+</header>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/page-header.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/page-header.scss
@@ -1,0 +1,33 @@
+@use '../styles/variables';
+
+.page-header {
+  background: var(--ee-surface);
+  padding: var(--ee-spacing-md) var(--ee-spacing-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  border-bottom: 1px solid var(--ee-divider);
+
+  &__left {
+    display: flex;
+    align-items: center;
+    gap: var(--ee-spacing-md);
+  }
+
+  &__title {
+    font-size: var(--ee-font-size-lg);
+    font-weight: 500;
+    color: var(--ee-on-surface);
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--ee-spacing-sm);
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/page-header.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/page-header.spec.ts
@@ -1,0 +1,123 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PageHeader } from './page-header';
+
+describe('PageHeader', () => {
+  let component: PageHeader;
+  let fixture: ComponentFixture<PageHeader>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PageHeader],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PageHeader);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('title', 'Test Title');
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the title', () => {
+    fixture.detectChanges();
+    const titleElement = fixture.nativeElement.querySelector(
+      '.page-header__title'
+    );
+    expect(titleElement.textContent.trim()).toBe('Test Title');
+  });
+
+  it('should show back button by default', () => {
+    fixture.detectChanges();
+    const backButton = fixture.nativeElement.querySelector(
+      'ee-icon-button[icon="arrow_back"]'
+    );
+    expect(backButton).toBeTruthy();
+  });
+
+  it('should hide back button when showBackButton is false', () => {
+    fixture.componentRef.setInput('showBackButton', false);
+    fixture.detectChanges();
+
+    const backButton = fixture.nativeElement.querySelector(
+      'ee-icon-button[icon="arrow_back"]'
+    );
+    expect(backButton).toBeFalsy();
+  });
+
+  it('should show help button by default', () => {
+    fixture.detectChanges();
+    const helpButton = fixture.nativeElement.querySelector(
+      'ee-icon-button[icon="help_outline"]'
+    );
+    expect(helpButton).toBeTruthy();
+  });
+
+  it('should hide help button when showHelpButton is false', () => {
+    fixture.componentRef.setInput('showHelpButton', false);
+    fixture.detectChanges();
+
+    const helpButton = fixture.nativeElement.querySelector(
+      'ee-icon-button[icon="help_outline"]'
+    );
+    expect(helpButton).toBeFalsy();
+  });
+
+  it('should show menu button by default', () => {
+    fixture.detectChanges();
+    const menuButton = fixture.nativeElement.querySelector(
+      'ee-icon-button[icon="more_vert"]'
+    );
+    expect(menuButton).toBeTruthy();
+  });
+
+  it('should hide menu button when showMenuButton is false', () => {
+    fixture.componentRef.setInput('showMenuButton', false);
+    fixture.detectChanges();
+
+    const menuButton = fixture.nativeElement.querySelector(
+      'ee-icon-button[icon="more_vert"]'
+    );
+    expect(menuButton).toBeFalsy();
+  });
+
+  it('should emit backClicked event when back button is clicked', () => {
+    fixture.detectChanges();
+    const backSpy = vi.fn();
+    component.backClicked.subscribe(backSpy);
+
+    const backButton = fixture.nativeElement.querySelector(
+      'ee-icon-button[icon="arrow_back"]'
+    );
+    backButton.dispatchEvent(new CustomEvent('clicked'));
+
+    expect(backSpy).toHaveBeenCalled();
+  });
+
+  it('should emit helpClicked event when help button is clicked', () => {
+    fixture.detectChanges();
+    const helpSpy = vi.fn();
+    component.helpClicked.subscribe(helpSpy);
+
+    const helpButton = fixture.nativeElement.querySelector(
+      'ee-icon-button[icon="help_outline"]'
+    );
+    helpButton.dispatchEvent(new CustomEvent('clicked'));
+
+    expect(helpSpy).toHaveBeenCalled();
+  });
+
+  it('should emit menuClicked event when menu button is clicked', () => {
+    fixture.detectChanges();
+    const menuSpy = vi.fn();
+    component.menuClicked.subscribe(menuSpy);
+
+    const menuButton = fixture.nativeElement.querySelector(
+      'ee-icon-button[icon="more_vert"]'
+    );
+    menuButton.dispatchEvent(new CustomEvent('clicked'));
+
+    expect(menuSpy).toHaveBeenCalled();
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/page-header.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/page-header.stories.ts
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { PageHeader } from './page-header';
+
+const meta: Meta<PageHeader> = {
+  title: 'Components/PageHeader',
+  component: PageHeader,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Header title text',
+    },
+    showBackButton: {
+      control: 'boolean',
+      description: 'Show the back navigation button',
+    },
+    showHelpButton: {
+      control: 'boolean',
+      description: 'Show the help button',
+    },
+    showMenuButton: {
+      control: 'boolean',
+      description: 'Show the menu button',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<PageHeader>;
+
+export const Default: Story = {
+  args: {
+    title: 'A La Carte Composer',
+    showBackButton: true,
+    showHelpButton: true,
+    showMenuButton: true,
+  },
+};
+
+export const SavedConfigurations: Story = {
+  args: {
+    title: 'Saved Configurations',
+    showBackButton: true,
+    showHelpButton: true,
+    showMenuButton: true,
+  },
+};
+
+export const ExecutingRequest: Story = {
+  args: {
+    title: 'Executing Request',
+    showBackButton: true,
+    showHelpButton: true,
+    showMenuButton: false,
+  },
+};
+
+export const NoBackButton: Story = {
+  args: {
+    title: 'Dashboard',
+    showBackButton: false,
+    showHelpButton: true,
+    showMenuButton: true,
+  },
+};
+
+export const MinimalHeader: Story = {
+  args: {
+    title: 'Simple Page',
+    showBackButton: false,
+    showHelpButton: false,
+    showMenuButton: false,
+  },
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/page-header.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/page-header/page-header.ts
@@ -1,0 +1,32 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IconButton } from '../icon-button';
+
+@Component({
+  selector: 'ee-page-header',
+  imports: [CommonModule, IconButton],
+  templateUrl: './page-header.html',
+  styleUrl: './page-header.scss',
+})
+export class PageHeader {
+  title = input.required<string>();
+  showBackButton = input<boolean>(true);
+  showHelpButton = input<boolean>(true);
+  showMenuButton = input<boolean>(true);
+
+  backClicked = output<void>();
+  helpClicked = output<void>();
+  menuClicked = output<void>();
+
+  onBackClick(): void {
+    this.backClicked.emit();
+  }
+
+  onHelpClick(): void {
+    this.helpClicked.emit();
+  }
+
+  onMenuClick(): void {
+    this.menuClicked.emit();
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/index.ts
@@ -1,0 +1,1 @@
+export * from './progress-bar';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/progress-bar.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/progress-bar.html
@@ -1,0 +1,19 @@
+<div class="progress-bar">
+  @if (label() || showPercentage()) {
+    <div class="progress-bar__text">
+      @if (label()) {
+        <span class="progress-bar__label">{{ label() }}</span>
+      }
+      @if (showPercentage()) {
+        <span class="progress-bar__percentage">{{ value() }}% Complete</span>
+      }
+    </div>
+  }
+  <div class="progress-bar__track">
+    <div
+      class="progress-bar__fill"
+      [class.progress-bar__fill--animated]="animated()"
+      [style.width.%]="value()"
+    ></div>
+  </div>
+</div>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/progress-bar.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/progress-bar.scss
@@ -1,0 +1,51 @@
+@use '../styles/variables';
+
+.progress-bar {
+  &__text {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: var(--ee-spacing-sm);
+    font-size: var(--ee-font-size-base);
+  }
+
+  &__label {
+    color: var(--ee-on-surface);
+  }
+
+  &__percentage {
+    color: var(--ee-on-surface-medium);
+  }
+
+  &__track {
+    width: 100%;
+    height: 8px;
+    background: var(--ee-surface-high);
+    border-radius: var(--ee-radius-sm);
+    overflow: hidden;
+  }
+
+  &__fill {
+    height: 100%;
+    background: linear-gradient(
+      90deg,
+      var(--ee-primary),
+      var(--ee-primary-lighter)
+    );
+    transition: width var(--ee-transition-slow);
+    border-radius: var(--ee-radius-sm);
+
+    &--animated {
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/progress-bar.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/progress-bar.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ProgressBar } from './progress-bar';
+
+describe('ProgressBar', () => {
+  let component: ProgressBar;
+  let fixture: ComponentFixture<ProgressBar>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProgressBar],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProgressBar);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display default value of 0', () => {
+    fixture.detectChanges();
+    const fillElement = fixture.nativeElement.querySelector(
+      '.progress-bar__fill'
+    );
+    expect(fillElement.style.width).toBe('0%');
+  });
+
+  it('should display the correct progress value', () => {
+    fixture.componentRef.setInput('value', 60);
+    fixture.detectChanges();
+
+    const fillElement = fixture.nativeElement.querySelector(
+      '.progress-bar__fill'
+    );
+    expect(fillElement.style.width).toBe('60%');
+  });
+
+  it('should display percentage by default', () => {
+    fixture.componentRef.setInput('value', 45);
+    fixture.detectChanges();
+
+    const percentageElement = fixture.nativeElement.querySelector(
+      '.progress-bar__percentage'
+    );
+    expect(percentageElement.textContent.trim()).toBe('45% Complete');
+  });
+
+  it('should hide percentage when showPercentage is false', () => {
+    fixture.componentRef.setInput('showPercentage', false);
+    fixture.detectChanges();
+
+    const percentageElement = fixture.nativeElement.querySelector(
+      '.progress-bar__percentage'
+    );
+    expect(percentageElement).toBeFalsy();
+  });
+
+  it('should display label when provided', () => {
+    fixture.componentRef.setInput('label', 'Overall Progress');
+    fixture.detectChanges();
+
+    const labelElement = fixture.nativeElement.querySelector(
+      '.progress-bar__label'
+    );
+    expect(labelElement.textContent.trim()).toBe('Overall Progress');
+  });
+
+  it('should apply animated class by default', () => {
+    fixture.detectChanges();
+    const fillElement = fixture.nativeElement.querySelector(
+      '.progress-bar__fill'
+    );
+    expect(
+      fillElement.classList.contains('progress-bar__fill--animated')
+    ).toBe(true);
+  });
+
+  it('should not apply animated class when animated is false', () => {
+    fixture.componentRef.setInput('animated', false);
+    fixture.detectChanges();
+
+    const fillElement = fixture.nativeElement.querySelector(
+      '.progress-bar__fill'
+    );
+    expect(
+      fillElement.classList.contains('progress-bar__fill--animated')
+    ).toBe(false);
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/progress-bar.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/progress-bar.stories.ts
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { ProgressBar } from './progress-bar';
+
+const meta: Meta<ProgressBar> = {
+  title: 'Components/ProgressBar',
+  component: ProgressBar,
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: { type: 'range', min: 0, max: 100 },
+      description: 'Progress value (0-100)',
+    },
+    label: {
+      control: 'text',
+      description: 'Label text',
+    },
+    showPercentage: {
+      control: 'boolean',
+      description: 'Show percentage text',
+    },
+    animated: {
+      control: 'boolean',
+      description: 'Enable pulse animation',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<ProgressBar>;
+
+export const Default: Story = {
+  args: {
+    value: 60,
+    label: 'Overall Progress',
+    showPercentage: true,
+    animated: true,
+  },
+};
+
+export const Starting: Story = {
+  args: {
+    value: 10,
+    label: 'Starting...',
+    animated: true,
+  },
+};
+
+export const Halfway: Story = {
+  args: {
+    value: 50,
+    label: 'Processing',
+    animated: true,
+  },
+};
+
+export const AlmostComplete: Story = {
+  args: {
+    value: 90,
+    label: 'Almost there',
+    animated: true,
+  },
+};
+
+export const Complete: Story = {
+  args: {
+    value: 100,
+    label: 'Complete',
+    animated: false,
+  },
+};
+
+export const NoLabel: Story = {
+  args: {
+    value: 75,
+    showPercentage: true,
+  },
+};
+
+export const NoPercentage: Story = {
+  args: {
+    value: 40,
+    label: 'Loading...',
+    showPercentage: false,
+    animated: true,
+  },
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/progress-bar.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/progress-bar/progress-bar.ts
@@ -1,0 +1,15 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'ee-progress-bar',
+  imports: [CommonModule],
+  templateUrl: './progress-bar.html',
+  styleUrl: './progress-bar.scss',
+})
+export class ProgressBar {
+  value = input<number>(0);
+  label = input<string>('');
+  showPercentage = input<boolean>(true);
+  animated = input<boolean>(true);
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/index.ts
@@ -1,0 +1,1 @@
+export * from './quick-option';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/quick-option.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/quick-option.html
@@ -1,0 +1,11 @@
+<button class="quick-option" (click)="onSelect()">
+  <div class="quick-option__icon">
+    <span class="material-icons">{{ icon() }}</span>
+  </div>
+  <div class="quick-option__content">
+    <div class="quick-option__title">{{ title() }}</div>
+    @if (description()) {
+      <div class="quick-option__description">{{ description() }}</div>
+    }
+  </div>
+</button>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/quick-option.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/quick-option.scss
@@ -1,0 +1,61 @@
+@use '../styles/variables';
+
+.quick-option {
+  display: flex;
+  align-items: center;
+  gap: var(--ee-spacing-md);
+  padding: var(--ee-spacing-lg);
+  background: var(--ee-surface-elevated);
+  border: 1px solid var(--ee-divider);
+  border-radius: var(--ee-radius-md);
+  cursor: pointer;
+  transition: all var(--ee-transition-base);
+  text-align: left;
+  width: 100%;
+
+  &:hover {
+    border-color: var(--ee-primary);
+    background: var(--ee-surface-high);
+  }
+
+  &:focus {
+    outline: 2px solid var(--ee-primary);
+    outline-offset: 2px;
+  }
+
+  &__icon {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--ee-surface-high);
+    border-radius: var(--ee-radius-md);
+    flex-shrink: 0;
+
+    .material-icons {
+      font-size: 24px;
+      color: var(--ee-primary);
+    }
+  }
+
+  &__content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__title {
+    font-size: var(--ee-font-size-base);
+    font-weight: 500;
+    margin-bottom: var(--ee-spacing-xs);
+    color: var(--ee-on-surface);
+  }
+
+  &__description {
+    font-size: var(--ee-font-size-sm);
+    color: var(--ee-on-surface-medium);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/quick-option.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/quick-option.spec.ts
@@ -1,0 +1,70 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { QuickOption } from './quick-option';
+
+describe('QuickOption', () => {
+  let component: QuickOption;
+  let fixture: ComponentFixture<QuickOption>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [QuickOption],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(QuickOption);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('icon', 'cloud');
+    fixture.componentRef.setInput('title', 'From GitHub');
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the icon', () => {
+    fixture.detectChanges();
+    const iconElement = fixture.nativeElement.querySelector(
+      '.quick-option__icon .material-icons'
+    );
+    expect(iconElement.textContent.trim()).toBe('cloud');
+  });
+
+  it('should display the title', () => {
+    fixture.detectChanges();
+    const titleElement = fixture.nativeElement.querySelector(
+      '.quick-option__title'
+    );
+    expect(titleElement.textContent.trim()).toBe('From GitHub');
+  });
+
+  it('should display description when provided', () => {
+    fixture.componentRef.setInput('description', 'Browse repository folders');
+    fixture.detectChanges();
+
+    const descriptionElement = fixture.nativeElement.querySelector(
+      '.quick-option__description'
+    );
+    expect(descriptionElement.textContent.trim()).toBe(
+      'Browse repository folders'
+    );
+  });
+
+  it('should not display description when not provided', () => {
+    fixture.detectChanges();
+    const descriptionElement = fixture.nativeElement.querySelector(
+      '.quick-option__description'
+    );
+    expect(descriptionElement).toBeFalsy();
+  });
+
+  it('should emit selected event when clicked', () => {
+    fixture.detectChanges();
+    const selectSpy = vi.fn();
+    component.selected.subscribe(selectSpy);
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(selectSpy).toHaveBeenCalled();
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/quick-option.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/quick-option.stories.ts
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { QuickOption } from './quick-option';
+
+const meta: Meta<QuickOption> = {
+  title: 'Components/QuickOption',
+  component: QuickOption,
+  tags: ['autodocs'],
+  argTypes: {
+    icon: {
+      control: 'text',
+      description: 'Material icon name',
+    },
+    title: {
+      control: 'text',
+      description: 'Option title',
+    },
+    description: {
+      control: 'text',
+      description: 'Option description',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<QuickOption>;
+
+export const FromGitHub: Story = {
+  args: {
+    icon: 'cloud',
+    title: 'From GitHub',
+    description: 'Browse repository folders',
+  },
+};
+
+export const FromLocal: Story = {
+  args: {
+    icon: 'folder',
+    title: 'From Local',
+    description: 'Select local directories',
+  },
+};
+
+export const Recent: Story = {
+  args: {
+    icon: 'history',
+    title: 'Recent',
+    description: 'View recent compositions',
+  },
+};
+
+export const Templates: Story = {
+  args: {
+    icon: 'dashboard',
+    title: 'Templates',
+    description: 'Use pre-built templates',
+  },
+};
+
+export const NoDescription: Story = {
+  args: {
+    icon: 'settings',
+    title: 'Settings',
+  },
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/quick-option.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/quick-option/quick-option.ts
@@ -1,0 +1,20 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'ee-quick-option',
+  imports: [CommonModule],
+  templateUrl: './quick-option.html',
+  styleUrl: './quick-option.scss',
+})
+export class QuickOption {
+  icon = input.required<string>();
+  title = input.required<string>();
+  description = input<string>('');
+
+  selected = output<void>();
+
+  onSelect(): void {
+    this.selected.emit();
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/index.ts
@@ -1,0 +1,1 @@
+export * from './search-box';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/search-box.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/search-box.html
@@ -1,0 +1,20 @@
+<div class="search-box">
+  <span class="material-icons search-box__icon">search</span>
+  <input
+    type="text"
+    class="search-box__input"
+    [placeholder]="placeholder()"
+    [value]="value()"
+    (input)="onInput($event)"
+  />
+  @if (value()) {
+    <button
+      type="button"
+      class="search-box__clear"
+      (click)="clear()"
+      aria-label="Clear search"
+    >
+      <span class="material-icons">close</span>
+    </button>
+  }
+</div>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/search-box.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/search-box.scss
@@ -1,0 +1,63 @@
+@use '../styles/variables';
+
+.search-box {
+  position: relative;
+  flex: 1;
+  min-width: 250px;
+
+  &__icon {
+    position: absolute;
+    left: var(--ee-spacing-md);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--ee-on-surface-disabled);
+    font-size: 20px;
+    pointer-events: none;
+  }
+
+  &__input {
+    width: 100%;
+    background: var(--ee-surface);
+    border: 1px solid var(--ee-divider);
+    border-radius: var(--ee-radius-md);
+    padding: 10px var(--ee-spacing-md) 10px 40px;
+    color: var(--ee-on-surface);
+    font-size: var(--ee-font-size-base);
+    font-family: var(--ee-font-family);
+    transition: border-color var(--ee-transition-base);
+
+    &::placeholder {
+      color: var(--ee-on-surface-disabled);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: var(--ee-primary);
+    }
+  }
+
+  &__clear {
+    position: absolute;
+    right: var(--ee-spacing-sm);
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: var(--ee-on-surface-medium);
+    cursor: pointer;
+    padding: var(--ee-spacing-xs);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--ee-radius-full);
+    transition: background var(--ee-transition-fast);
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .material-icons {
+      font-size: 18px;
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/search-box.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/search-box.spec.ts
@@ -1,0 +1,87 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SearchBox } from './search-box';
+
+describe('SearchBox', () => {
+  let component: SearchBox;
+  let fixture: ComponentFixture<SearchBox>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SearchBox],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchBox);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the search icon', () => {
+    fixture.detectChanges();
+    const iconElement = fixture.nativeElement.querySelector(
+      '.search-box__icon'
+    );
+    expect(iconElement.textContent.trim()).toBe('search');
+  });
+
+  it('should display the placeholder', () => {
+    fixture.componentRef.setInput('placeholder', 'Search configurations...');
+    fixture.detectChanges();
+
+    const inputElement = fixture.nativeElement.querySelector(
+      '.search-box__input'
+    );
+    expect(inputElement.placeholder).toBe('Search configurations...');
+  });
+
+  it('should emit searchChanged event on input', () => {
+    fixture.detectChanges();
+    const searchSpy = vi.fn();
+    component.searchChanged.subscribe(searchSpy);
+
+    const inputElement = fixture.nativeElement.querySelector(
+      '.search-box__input'
+    );
+    inputElement.value = 'test';
+    inputElement.dispatchEvent(new Event('input'));
+
+    expect(searchSpy).toHaveBeenCalledWith('test');
+  });
+
+  it('should not show clear button when value is empty', () => {
+    fixture.detectChanges();
+    const clearButton = fixture.nativeElement.querySelector(
+      '.search-box__clear'
+    );
+    expect(clearButton).toBeFalsy();
+  });
+
+  it('should show clear button when value is not empty', () => {
+    component.value.set('test');
+    fixture.detectChanges();
+
+    const clearButton = fixture.nativeElement.querySelector(
+      '.search-box__clear'
+    );
+    expect(clearButton).toBeTruthy();
+  });
+
+  it('should clear value and emit event when clear button is clicked', () => {
+    component.value.set('test');
+    fixture.detectChanges();
+
+    const searchSpy = vi.fn();
+    component.searchChanged.subscribe(searchSpy);
+
+    const clearButton = fixture.nativeElement.querySelector(
+      '.search-box__clear'
+    );
+    clearButton.click();
+
+    expect(component.value()).toBe('');
+    expect(searchSpy).toHaveBeenCalledWith('');
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/search-box.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/search-box.stories.ts
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { SearchBox } from './search-box';
+
+const meta: Meta<SearchBox> = {
+  title: 'Components/SearchBox',
+  component: SearchBox,
+  tags: ['autodocs'],
+  argTypes: {
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<SearchBox>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Search...',
+  },
+};
+
+export const SearchConfigurations: Story = {
+  args: {
+    placeholder: 'Search configurations...',
+  },
+};
+
+export const WithValue: Story = {
+  render: () => ({
+    template: `
+      <ee-search-box placeholder="Search..." [value]="'e-commerce'"></ee-search-box>
+    `,
+  }),
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/search-box.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/search-box/search-box.ts
@@ -1,0 +1,27 @@
+import { Component, input, output, model } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'ee-search-box',
+  imports: [CommonModule, FormsModule],
+  templateUrl: './search-box.html',
+  styleUrl: './search-box.scss',
+})
+export class SearchBox {
+  placeholder = input<string>('Search...');
+  value = model<string>('');
+
+  searchChanged = output<string>();
+
+  onInput(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    this.value.set(target.value);
+    this.searchChanged.emit(target.value);
+  }
+
+  clear(): void {
+    this.value.set('');
+    this.searchChanged.emit('');
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/index.ts
@@ -1,0 +1,1 @@
+export * from './stage-list';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/stage-list.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/stage-list.html
@@ -1,0 +1,32 @@
+<div class="stage-list">
+  @for (stage of stages(); track stage.name) {
+    <div
+      class="stage-list__item"
+      [class.stage-list__item--active]="stage.status === 'active'"
+      [class.stage-list__item--completed]="stage.status === 'completed'"
+      [class.stage-list__item--error]="stage.status === 'error'"
+    >
+      <span
+        class="material-icons stage-list__icon"
+        [class.stage-list__icon--pending]="stage.status === 'pending'"
+        [class.stage-list__icon--active]="stage.status === 'active'"
+        [class.stage-list__icon--completed]="stage.status === 'completed'"
+        [class.stage-list__icon--error]="stage.status === 'error'"
+      >
+        {{ getIconForStatus(stage.status) }}
+      </span>
+
+      <div class="stage-list__details">
+        <div class="stage-list__name">{{ stage.name }}</div>
+        @if (stage.description) {
+          <div class="stage-list__status">{{ stage.description }}</div>
+        }
+      </div>
+
+      <ee-badge
+        [label]="getBadgeLabel(stage.status)"
+        [variant]="getBadgeVariant(stage.status)"
+      ></ee-badge>
+    </div>
+  }
+</div>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/stage-list.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/stage-list.scss
@@ -1,0 +1,75 @@
+@use '../styles/variables';
+
+.stage-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ee-spacing-md);
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: var(--ee-spacing-md);
+    padding: var(--ee-spacing-md);
+    background: var(--ee-surface-high);
+    border-radius: var(--ee-radius-sm);
+    border: 1px solid transparent;
+
+    &--active {
+      border-color: var(--ee-primary);
+    }
+
+    &--completed {
+      border-color: var(--ee-success);
+    }
+
+    &--error {
+      border-color: var(--ee-warn);
+    }
+  }
+
+  &__icon {
+    font-size: 24px;
+
+    &--pending {
+      color: var(--ee-on-surface-disabled);
+    }
+
+    &--active {
+      color: var(--ee-primary);
+      animation: spin 1s linear infinite;
+    }
+
+    &--completed {
+      color: var(--ee-success);
+    }
+
+    &--error {
+      color: var(--ee-warn);
+    }
+  }
+
+  &__details {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__name {
+    font-weight: 500;
+    margin-bottom: var(--ee-spacing-xs);
+    color: var(--ee-on-surface);
+  }
+
+  &__status {
+    font-size: var(--ee-font-size-md);
+    color: var(--ee-on-surface-medium);
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/stage-list.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/stage-list.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StageList, Stage } from './stage-list';
+
+describe('StageList', () => {
+  let component: StageList;
+  let fixture: ComponentFixture<StageList>;
+  const mockStages: Stage[] = [
+    { name: 'Clone Repositories', status: 'completed', description: '5 of 5 repositories cloned' },
+    { name: 'Validate Folders', status: 'completed', description: '9 folders validated' },
+    { name: 'Copy Project Folders', status: 'active', description: 'Copying files...' },
+    { name: 'Create Solution File', status: 'pending', description: 'Waiting...' },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StageList],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StageList);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('stages', mockStages);
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render all stages', () => {
+    fixture.detectChanges();
+    const stageElements = fixture.nativeElement.querySelectorAll('.stage-list__item');
+    expect(stageElements.length).toBe(4);
+  });
+
+  it('should display stage names', () => {
+    fixture.detectChanges();
+    const nameElements = fixture.nativeElement.querySelectorAll('.stage-list__name');
+    expect(nameElements[0].textContent.trim()).toBe('Clone Repositories');
+    expect(nameElements[2].textContent.trim()).toBe('Copy Project Folders');
+  });
+
+  it('should display stage descriptions', () => {
+    fixture.detectChanges();
+    const statusElements = fixture.nativeElement.querySelectorAll('.stage-list__status');
+    expect(statusElements[0].textContent.trim()).toBe('5 of 5 repositories cloned');
+  });
+
+  it('should apply active class to active stages', () => {
+    fixture.detectChanges();
+    const stageElements = fixture.nativeElement.querySelectorAll('.stage-list__item');
+    expect(stageElements[2].classList.contains('stage-list__item--active')).toBe(true);
+  });
+
+  it('should apply completed class to completed stages', () => {
+    fixture.detectChanges();
+    const stageElements = fixture.nativeElement.querySelectorAll('.stage-list__item');
+    expect(stageElements[0].classList.contains('stage-list__item--completed')).toBe(true);
+  });
+
+  it('should return correct icon for status', () => {
+    expect(component.getIconForStatus('completed')).toBe('check_circle');
+    expect(component.getIconForStatus('active')).toBe('hourglass_empty');
+    expect(component.getIconForStatus('pending')).toBe('radio_button_unchecked');
+    expect(component.getIconForStatus('error')).toBe('error');
+  });
+
+  it('should return correct badge variant', () => {
+    expect(component.getBadgeVariant('completed')).toBe('success');
+    expect(component.getBadgeVariant('active')).toBe('processing');
+    expect(component.getBadgeVariant('pending')).toBe('pending');
+    expect(component.getBadgeVariant('error')).toBe('error');
+  });
+
+  it('should return correct badge label', () => {
+    expect(component.getBadgeLabel('completed')).toBe('Completed');
+    expect(component.getBadgeLabel('active')).toBe('Processing');
+    expect(component.getBadgeLabel('pending')).toBe('Pending');
+    expect(component.getBadgeLabel('error')).toBe('Failed');
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/stage-list.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/stage-list.stories.ts
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { StageList, Stage } from './stage-list';
+
+const meta: Meta<StageList> = {
+  title: 'Components/StageList',
+  component: StageList,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<StageList>;
+
+export const InProgress: Story = {
+  args: {
+    stages: [
+      { name: 'Clone Repositories', status: 'completed', description: '5 of 5 repositories cloned' },
+      { name: 'Validate Folders', status: 'completed', description: '9 folders validated' },
+      { name: 'Copy Project Folders', status: 'active', description: 'Copying files to output directory...' },
+      { name: 'Create Solution File', status: 'pending', description: 'Waiting...' },
+      { name: 'Link Projects', status: 'pending', description: 'Waiting...' },
+    ] as Stage[],
+  },
+};
+
+export const AllCompleted: Story = {
+  args: {
+    stages: [
+      { name: 'Clone Repositories', status: 'completed', description: '5 of 5 repositories cloned' },
+      { name: 'Validate Folders', status: 'completed', description: '9 folders validated' },
+      { name: 'Copy Project Folders', status: 'completed', description: 'All files copied' },
+      { name: 'Create Solution File', status: 'completed', description: 'Solution created' },
+      { name: 'Link Projects', status: 'completed', description: 'All projects linked' },
+    ] as Stage[],
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    stages: [
+      { name: 'Clone Repositories', status: 'completed', description: '4 of 5 repositories cloned' },
+      { name: 'Validate Folders', status: 'error', description: 'Missing folder: src/Auth' },
+      { name: 'Copy Project Folders', status: 'pending', description: 'Waiting...' },
+    ] as Stage[],
+  },
+};
+
+export const JustStarted: Story = {
+  args: {
+    stages: [
+      { name: 'Initialize', status: 'active', description: 'Setting up environment...' },
+      { name: 'Download Dependencies', status: 'pending' },
+      { name: 'Build Project', status: 'pending' },
+      { name: 'Run Tests', status: 'pending' },
+    ] as Stage[],
+  },
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/stage-list.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stage-list/stage-list.ts
@@ -1,0 +1,60 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Badge, BadgeVariant } from '../badge';
+
+export type StageStatus = 'pending' | 'active' | 'completed' | 'error';
+
+export interface Stage {
+  name: string;
+  status: StageStatus;
+  description?: string;
+}
+
+@Component({
+  selector: 'ee-stage-list',
+  imports: [CommonModule, Badge],
+  templateUrl: './stage-list.html',
+  styleUrl: './stage-list.scss',
+})
+export class StageList {
+  stages = input.required<Stage[]>();
+
+  getIconForStatus(status: StageStatus): string {
+    switch (status) {
+      case 'completed':
+        return 'check_circle';
+      case 'active':
+        return 'hourglass_empty';
+      case 'error':
+        return 'error';
+      default:
+        return 'radio_button_unchecked';
+    }
+  }
+
+  getBadgeVariant(status: StageStatus): BadgeVariant {
+    switch (status) {
+      case 'completed':
+        return 'success';
+      case 'active':
+        return 'processing';
+      case 'error':
+        return 'error';
+      default:
+        return 'pending';
+    }
+  }
+
+  getBadgeLabel(status: StageStatus): string {
+    switch (status) {
+      case 'completed':
+        return 'Completed';
+      case 'active':
+        return 'Processing';
+      case 'error':
+        return 'Failed';
+      default:
+        return 'Pending';
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/index.ts
@@ -1,0 +1,1 @@
+export * from './stats-bar';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/stats-bar.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/stats-bar.html
@@ -1,0 +1,8 @@
+<div class="stats-bar">
+  @for (stat of stats(); track stat.label) {
+    <div class="stats-bar__stat">
+      <div class="stats-bar__value">{{ stat.value }}</div>
+      <div class="stats-bar__label">{{ stat.label }}</div>
+    </div>
+  }
+</div>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/stats-bar.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/stats-bar.scss
@@ -1,0 +1,36 @@
+@use '../styles/variables';
+
+.stats-bar {
+  display: flex;
+  gap: var(--ee-spacing-xl);
+  padding: 20px;
+  background: var(--ee-surface);
+  border: 1px solid var(--ee-divider);
+  border-radius: var(--ee-radius-lg);
+
+  &__stat {
+    flex: 1;
+    text-align: center;
+  }
+
+  &__value {
+    font-size: var(--ee-font-size-display);
+    font-weight: 500;
+    color: var(--ee-primary);
+    margin-bottom: var(--ee-spacing-xs);
+  }
+
+  &__label {
+    font-size: var(--ee-font-size-sm);
+    color: var(--ee-on-surface-medium);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+}
+
+@media (max-width: 480px) {
+  .stats-bar {
+    flex-direction: column;
+    gap: var(--ee-spacing-lg);
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/stats-bar.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/stats-bar.spec.ts
@@ -1,0 +1,67 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StatsBar, StatItem } from './stats-bar';
+
+describe('StatsBar', () => {
+  let component: StatsBar;
+  let fixture: ComponentFixture<StatsBar>;
+  const mockStats: StatItem[] = [
+    { value: 12, label: 'Saved Configs' },
+    { value: 48, label: 'Total Repos' },
+    { value: 127, label: 'Components' },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StatsBar],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StatsBar);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('stats', mockStats);
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render all stats', () => {
+    fixture.detectChanges();
+    const statElements = fixture.nativeElement.querySelectorAll(
+      '.stats-bar__stat'
+    );
+    expect(statElements.length).toBe(3);
+  });
+
+  it('should display stat values', () => {
+    fixture.detectChanges();
+    const valueElements = fixture.nativeElement.querySelectorAll(
+      '.stats-bar__value'
+    );
+    expect(valueElements[0].textContent.trim()).toBe('12');
+    expect(valueElements[1].textContent.trim()).toBe('48');
+    expect(valueElements[2].textContent.trim()).toBe('127');
+  });
+
+  it('should display stat labels', () => {
+    fixture.detectChanges();
+    const labelElements = fixture.nativeElement.querySelectorAll(
+      '.stats-bar__label'
+    );
+    expect(labelElements[0].textContent.trim()).toBe('Saved Configs');
+    expect(labelElements[1].textContent.trim()).toBe('Total Repos');
+    expect(labelElements[2].textContent.trim()).toBe('Components');
+  });
+
+  it('should handle string values', () => {
+    fixture.componentRef.setInput('stats', [
+      { value: '1.2K', label: 'Downloads' },
+    ]);
+    fixture.detectChanges();
+
+    const valueElement = fixture.nativeElement.querySelector(
+      '.stats-bar__value'
+    );
+    expect(valueElement.textContent.trim()).toBe('1.2K');
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/stats-bar.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/stats-bar.stories.ts
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { StatsBar, StatItem } from './stats-bar';
+
+const meta: Meta<StatsBar> = {
+  title: 'Components/StatsBar',
+  component: StatsBar,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<StatsBar>;
+
+export const ConfigurationStats: Story = {
+  args: {
+    stats: [
+      { value: 12, label: 'Saved Configs' },
+      { value: 48, label: 'Total Repos' },
+      { value: 127, label: 'Components' },
+    ] as StatItem[],
+  },
+};
+
+export const ProjectStats: Story = {
+  args: {
+    stats: [
+      { value: 5, label: 'Projects' },
+      { value: 23, label: 'Branches' },
+      { value: 156, label: 'Commits' },
+    ] as StatItem[],
+  },
+};
+
+export const TwoStats: Story = {
+  args: {
+    stats: [
+      { value: 3, label: 'Repositories' },
+      { value: 12, label: 'Folders' },
+    ] as StatItem[],
+  },
+};
+
+export const WithFormattedValues: Story = {
+  args: {
+    stats: [
+      { value: '1.2K', label: 'Downloads' },
+      { value: '99%', label: 'Uptime' },
+      { value: '4.8', label: 'Rating' },
+    ] as StatItem[],
+  },
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/stats-bar.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/stats-bar/stats-bar.ts
@@ -1,0 +1,17 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface StatItem {
+  value: number | string;
+  label: string;
+}
+
+@Component({
+  selector: 'ee-stats-bar',
+  imports: [CommonModule],
+  templateUrl: './stats-bar.html',
+  styleUrl: './stats-bar.scss',
+})
+export class StatsBar {
+  stats = input.required<StatItem[]>();
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/styles/_variables.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/styles/_variables.scss
@@ -1,0 +1,69 @@
+// Angular Material Dark Theme - Indigo/Pink Color Palette
+// Based on the design system from the UI mockups
+
+:root {
+  // Primary Colors
+  --ee-primary: #9fa8da;
+  --ee-primary-lighter: #c5cae9;
+  --ee-primary-darker: #7986cb;
+
+  // Accent Colors
+  --ee-accent: #f48fb1;
+  --ee-accent-lighter: #f8bbd0;
+  --ee-accent-darker: #f06292;
+
+  // Semantic Colors
+  --ee-warn: #ef5350;
+  --ee-success: #81c784;
+
+  // Background Colors
+  --ee-background: #0d1117;
+  --ee-surface: #161b22;
+  --ee-surface-elevated: #21262d;
+  --ee-surface-high: #30363d;
+
+  // Text Colors
+  --ee-on-surface: #e6edf3;
+  --ee-on-surface-medium: rgba(230, 237, 243, 0.7);
+  --ee-on-surface-disabled: rgba(230, 237, 243, 0.38);
+
+  // Border Colors
+  --ee-divider: rgba(230, 237, 243, 0.12);
+
+  // Spacing
+  --ee-spacing-xs: 4px;
+  --ee-spacing-sm: 8px;
+  --ee-spacing-md: 12px;
+  --ee-spacing-lg: 16px;
+  --ee-spacing-xl: 24px;
+  --ee-spacing-xxl: 32px;
+
+  // Border Radius
+  --ee-radius-sm: 4px;
+  --ee-radius-md: 8px;
+  --ee-radius-lg: 12px;
+  --ee-radius-full: 50%;
+
+  // Typography
+  --ee-font-family: 'Roboto', sans-serif;
+  --ee-font-size-xs: 11px;
+  --ee-font-size-sm: 12px;
+  --ee-font-size-md: 13px;
+  --ee-font-size-base: 14px;
+  --ee-font-size-lg: 16px;
+  --ee-font-size-xl: 18px;
+  --ee-font-size-xxl: 20px;
+  --ee-font-size-title: 24px;
+  --ee-font-size-display: 28px;
+
+  // Shadows
+  --ee-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.1);
+  --ee-shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --ee-shadow-lg: 0 11px 15px -7px rgba(0, 0, 0, 0.2),
+    0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12);
+
+  // Transitions
+  --ee-transition-fast: 0.15s ease;
+  --ee-transition-base: 0.2s ease;
+  --ee-transition-slow: 0.3s ease;
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/styles/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/styles/index.ts
@@ -1,0 +1,2 @@
+// Styles barrel export
+// Note: SCSS files should be imported directly in component stylesheets

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/index.ts
@@ -1,0 +1,1 @@
+export * from './tag';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/tag.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/tag.html
@@ -1,0 +1,18 @@
+<span
+  class="tag"
+  [class.tag--github]="variant() === 'github'"
+  [class.tag--local]="variant() === 'local'"
+  [class.tag--primary]="variant() === 'primary'"
+>
+  {{ label() }}
+  @if (removable()) {
+    <button
+      class="tag__remove"
+      type="button"
+      (click)="onRemove($event)"
+      aria-label="Remove tag"
+    >
+      <span class="material-icons">close</span>
+    </button>
+  }
+</span>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/tag.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/tag.scss
@@ -1,0 +1,50 @@
+@use '../styles/variables';
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--ee-font-size-xs);
+  padding: var(--ee-spacing-xs) var(--ee-spacing-sm);
+  border-radius: var(--ee-radius-sm);
+  background: var(--ee-surface-elevated);
+  color: var(--ee-on-surface-medium);
+
+  &--github {
+    background: rgba(35, 134, 54, 0.2);
+    color: #3fb950;
+  }
+
+  &--local {
+    background: rgba(244, 143, 177, 0.2);
+    color: var(--ee-accent);
+  }
+
+  &--primary {
+    background: var(--ee-primary-darker);
+    color: white;
+    border-radius: 16px;
+    padding: var(--ee-spacing-xs) var(--ee-spacing-md);
+  }
+
+  &__remove {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.7;
+    transition: opacity var(--ee-transition-fast);
+
+    &:hover {
+      opacity: 1;
+    }
+
+    .material-icons {
+      font-size: 14px;
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/tag.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/tag.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Tag } from './tag';
+
+describe('Tag', () => {
+  let component: Tag;
+  let fixture: ComponentFixture<Tag>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Tag],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Tag);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('label', 'Test Tag');
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the label', () => {
+    fixture.detectChanges();
+    const tagElement = fixture.nativeElement.querySelector('.tag');
+    expect(tagElement.textContent.trim()).toBe('Test Tag');
+  });
+
+  it('should apply default variant by default', () => {
+    fixture.detectChanges();
+    const tagElement = fixture.nativeElement.querySelector('.tag');
+    expect(tagElement.classList.contains('tag--github')).toBe(false);
+    expect(tagElement.classList.contains('tag--local')).toBe(false);
+  });
+
+  it('should apply github variant', () => {
+    fixture.componentRef.setInput('variant', 'github');
+    fixture.detectChanges();
+
+    const tagElement = fixture.nativeElement.querySelector('.tag');
+    expect(tagElement.classList.contains('tag--github')).toBe(true);
+  });
+
+  it('should apply local variant', () => {
+    fixture.componentRef.setInput('variant', 'local');
+    fixture.detectChanges();
+
+    const tagElement = fixture.nativeElement.querySelector('.tag');
+    expect(tagElement.classList.contains('tag--local')).toBe(true);
+  });
+
+  it('should apply primary variant', () => {
+    fixture.componentRef.setInput('variant', 'primary');
+    fixture.detectChanges();
+
+    const tagElement = fixture.nativeElement.querySelector('.tag');
+    expect(tagElement.classList.contains('tag--primary')).toBe(true);
+  });
+
+  it('should not show remove button by default', () => {
+    fixture.detectChanges();
+    const removeButton = fixture.nativeElement.querySelector('.tag__remove');
+    expect(removeButton).toBeFalsy();
+  });
+
+  it('should show remove button when removable', () => {
+    fixture.componentRef.setInput('removable', true);
+    fixture.detectChanges();
+
+    const removeButton = fixture.nativeElement.querySelector('.tag__remove');
+    expect(removeButton).toBeTruthy();
+  });
+
+  it('should emit removed event when remove button is clicked', () => {
+    fixture.componentRef.setInput('removable', true);
+    fixture.detectChanges();
+
+    const removeSpy = vi.fn();
+    component.removed.subscribe(removeSpy);
+
+    const removeButton = fixture.nativeElement.querySelector('.tag__remove');
+    removeButton.click();
+
+    expect(removeSpy).toHaveBeenCalled();
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/tag.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/tag.stories.ts
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { Tag } from './tag';
+
+const meta: Meta<Tag> = {
+  title: 'Components/Tag',
+  component: Tag,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Tag label text',
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'github', 'local', 'primary'],
+      description: 'Tag style variant',
+    },
+    removable: {
+      control: 'boolean',
+      description: 'Show remove button',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<Tag>;
+
+export const Default: Story = {
+  args: {
+    label: '.NET 8',
+    variant: 'default',
+    removable: false,
+  },
+};
+
+export const GitHub: Story = {
+  args: {
+    label: 'GitHub',
+    variant: 'github',
+  },
+};
+
+export const Local: Story = {
+  args: {
+    label: 'Local',
+    variant: 'local',
+  },
+};
+
+export const Primary: Story = {
+  args: {
+    label: 'api',
+    variant: 'primary',
+    removable: true,
+  },
+};
+
+export const Removable: Story = {
+  args: {
+    label: 'microservice',
+    variant: 'primary',
+    removable: true,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => ({
+    template: `
+      <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+        <ee-tag label=".NET 8"></ee-tag>
+        <ee-tag label="GitHub" variant="github"></ee-tag>
+        <ee-tag label="Local" variant="local"></ee-tag>
+        <ee-tag label="api" variant="primary" [removable]="true"></ee-tag>
+        <ee-tag label="Docker"></ee-tag>
+      </div>
+    `,
+  }),
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/tag.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/tag/tag.ts
@@ -1,0 +1,23 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type TagVariant = 'default' | 'github' | 'local' | 'primary';
+
+@Component({
+  selector: 'ee-tag',
+  imports: [CommonModule],
+  templateUrl: './tag.html',
+  styleUrl: './tag.scss',
+})
+export class Tag {
+  label = input.required<string>();
+  variant = input<TagVariant>('default');
+  removable = input<boolean>(false);
+
+  removed = output<void>();
+
+  onRemove(event: Event): void {
+    event.stopPropagation();
+    this.removed.emit();
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/index.ts
@@ -1,0 +1,1 @@
+export * from './warning-box';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/warning-box.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/warning-box.html
@@ -1,0 +1,15 @@
+<div
+  class="warning-box"
+  [class.warning-box--warning]="variant() === 'warning'"
+  [class.warning-box--error]="variant() === 'error'"
+  [class.warning-box--info]="variant() === 'info'"
+  [class.warning-box--success]="variant() === 'success'"
+>
+  <span class="material-icons warning-box__icon">{{ getIcon() }}</span>
+  <div class="warning-box__content">
+    @if (title()) {
+      <strong class="warning-box__title">{{ title() }}</strong>
+    }
+    <span class="warning-box__message">{{ message() }}</span>
+  </div>
+</div>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/warning-box.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/warning-box.scss
@@ -1,0 +1,66 @@
+@use '../styles/variables';
+
+.warning-box {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--ee-spacing-md);
+  padding: var(--ee-spacing-lg);
+  border-radius: var(--ee-radius-sm);
+
+  &--warning {
+    background: rgba(255, 170, 0, 0.1);
+    border: 1px solid #ffaa00;
+
+    .warning-box__icon {
+      color: #ffaa00;
+    }
+  }
+
+  &--error {
+    background: rgba(239, 83, 80, 0.1);
+    border: 1px solid var(--ee-warn);
+
+    .warning-box__icon {
+      color: var(--ee-warn);
+    }
+  }
+
+  &--info {
+    background: rgba(159, 168, 218, 0.1);
+    border: 1px solid var(--ee-primary);
+
+    .warning-box__icon {
+      color: var(--ee-primary);
+    }
+  }
+
+  &--success {
+    background: rgba(129, 199, 132, 0.1);
+    border: 1px solid var(--ee-success);
+
+    .warning-box__icon {
+      color: var(--ee-success);
+    }
+  }
+
+  &__icon {
+    font-size: 20px;
+    flex-shrink: 0;
+  }
+
+  &__content {
+    flex: 1;
+    font-size: var(--ee-font-size-base);
+    line-height: 1.5;
+    color: var(--ee-on-surface);
+  }
+
+  &__title {
+    display: block;
+    margin-bottom: var(--ee-spacing-xs);
+  }
+
+  &__message {
+    color: var(--ee-on-surface-medium);
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/warning-box.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/warning-box.spec.ts
@@ -1,0 +1,94 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { WarningBox } from './warning-box';
+
+describe('WarningBox', () => {
+  let component: WarningBox;
+  let fixture: ComponentFixture<WarningBox>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WarningBox],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WarningBox);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('message', 'This is a warning message');
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the message', () => {
+    fixture.detectChanges();
+    const messageElement = fixture.nativeElement.querySelector('.warning-box__message');
+    expect(messageElement.textContent.trim()).toBe('This is a warning message');
+  });
+
+  it('should display title when provided', () => {
+    fixture.componentRef.setInput('title', 'Warning:');
+    fixture.detectChanges();
+
+    const titleElement = fixture.nativeElement.querySelector('.warning-box__title');
+    expect(titleElement.textContent.trim()).toBe('Warning:');
+  });
+
+  it('should not display title when not provided', () => {
+    fixture.detectChanges();
+    const titleElement = fixture.nativeElement.querySelector('.warning-box__title');
+    expect(titleElement).toBeFalsy();
+  });
+
+  it('should apply warning variant by default', () => {
+    fixture.detectChanges();
+    const warningBox = fixture.nativeElement.querySelector('.warning-box');
+    expect(warningBox.classList.contains('warning-box--warning')).toBe(true);
+  });
+
+  it('should apply error variant', () => {
+    fixture.componentRef.setInput('variant', 'error');
+    fixture.detectChanges();
+
+    const warningBox = fixture.nativeElement.querySelector('.warning-box');
+    expect(warningBox.classList.contains('warning-box--error')).toBe(true);
+  });
+
+  it('should apply info variant', () => {
+    fixture.componentRef.setInput('variant', 'info');
+    fixture.detectChanges();
+
+    const warningBox = fixture.nativeElement.querySelector('.warning-box');
+    expect(warningBox.classList.contains('warning-box--info')).toBe(true);
+  });
+
+  it('should apply success variant', () => {
+    fixture.componentRef.setInput('variant', 'success');
+    fixture.detectChanges();
+
+    const warningBox = fixture.nativeElement.querySelector('.warning-box');
+    expect(warningBox.classList.contains('warning-box--success')).toBe(true);
+  });
+
+  it('should return correct icon for warning', () => {
+    expect(component.getIcon()).toBe('warning_amber');
+  });
+
+  it('should return correct icon for error', () => {
+    fixture.componentRef.setInput('variant', 'error');
+    fixture.detectChanges();
+    expect(component.getIcon()).toBe('error_outline');
+  });
+
+  it('should return correct icon for info', () => {
+    fixture.componentRef.setInput('variant', 'info');
+    fixture.detectChanges();
+    expect(component.getIcon()).toBe('info_outline');
+  });
+
+  it('should return correct icon for success', () => {
+    fixture.componentRef.setInput('variant', 'success');
+    fixture.detectChanges();
+    expect(component.getIcon()).toBe('check_circle_outline');
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/warning-box.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/warning-box.stories.ts
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { WarningBox } from './warning-box';
+
+const meta: Meta<WarningBox> = {
+  title: 'Components/WarningBox',
+  component: WarningBox,
+  tags: ['autodocs'],
+  argTypes: {
+    message: {
+      control: 'text',
+      description: 'Warning message text',
+    },
+    title: {
+      control: 'text',
+      description: 'Optional title',
+    },
+    variant: {
+      control: 'select',
+      options: ['warning', 'error', 'info', 'success'],
+      description: 'Warning box variant',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<WarningBox>;
+
+export const Warning: Story = {
+  args: {
+    variant: 'warning',
+    title: 'Warning:',
+    message: 'This action may take a few minutes to complete.',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    variant: 'error',
+    title: 'Error:',
+    message: 'Deleting this request is permanent. All configuration data will be lost. Generated solutions will not be affected.',
+  },
+};
+
+export const Info: Story = {
+  args: {
+    variant: 'info',
+    message: 'You can customize the output directory in the settings.',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    variant: 'success',
+    title: 'Success!',
+    message: 'Your configuration has been saved successfully.',
+  },
+};
+
+export const NoTitle: Story = {
+  args: {
+    variant: 'warning',
+    message: 'Please review the changes before proceeding.',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => ({
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 16px;">
+        <ee-warning-box variant="info" title="Info:" message="This is an informational message."></ee-warning-box>
+        <ee-warning-box variant="success" title="Success:" message="Operation completed successfully."></ee-warning-box>
+        <ee-warning-box variant="warning" title="Warning:" message="Please be careful with this action."></ee-warning-box>
+        <ee-warning-box variant="error" title="Error:" message="Something went wrong."></ee-warning-box>
+      </div>
+    `,
+  }),
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/warning-box.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/warning-box/warning-box.ts
@@ -1,0 +1,29 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type WarningVariant = 'warning' | 'error' | 'info' | 'success';
+
+@Component({
+  selector: 'ee-warning-box',
+  imports: [CommonModule],
+  templateUrl: './warning-box.html',
+  styleUrl: './warning-box.scss',
+})
+export class WarningBox {
+  message = input.required<string>();
+  variant = input<WarningVariant>('warning');
+  title = input<string>('');
+
+  getIcon(): string {
+    switch (this.variant()) {
+      case 'error':
+        return 'error_outline';
+      case 'info':
+        return 'info_outline';
+      case 'success':
+        return 'check_circle_outline';
+      default:
+        return 'warning_amber';
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/index.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/index.ts
@@ -1,0 +1,1 @@
+export * from './wizard-steps';

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/wizard-steps.html
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/wizard-steps.html
@@ -1,0 +1,24 @@
+<div class="wizard-steps">
+  @for (step of steps(); track $index; let i = $index; let last = $last) {
+    <div
+      class="wizard-steps__step"
+      [class.wizard-steps__step--active]="i === currentStep()"
+      [class.wizard-steps__step--completed]="step.completed || i < currentStep()"
+    >
+      <div class="wizard-steps__indicator">
+        @if (step.completed || i < currentStep()) {
+          <span class="material-icons wizard-steps__check">check</span>
+        } @else {
+          {{ i + 1 }}
+        }
+      </div>
+      <span class="wizard-steps__label">{{ step.label }}</span>
+    </div>
+    @if (!last) {
+      <div
+        class="wizard-steps__connector"
+        [class.wizard-steps__connector--completed]="i < currentStep()"
+      ></div>
+    }
+  }
+</div>

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/wizard-steps.scss
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/wizard-steps.scss
@@ -1,0 +1,70 @@
+@use '../styles/variables';
+
+.wizard-steps {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--ee-spacing-xxl);
+  overflow-x: auto;
+
+  &__step {
+    display: flex;
+    align-items: center;
+    gap: var(--ee-spacing-md);
+  }
+
+  &__indicator {
+    width: 32px;
+    height: 32px;
+    border-radius: var(--ee-radius-full);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--ee-font-size-base);
+    font-weight: 500;
+    background: var(--ee-surface-elevated);
+    color: var(--ee-on-surface-medium);
+    border: 2px solid var(--ee-divider);
+    flex-shrink: 0;
+    transition: all var(--ee-transition-base);
+
+    .wizard-steps__step--active & {
+      background: var(--ee-primary);
+      color: #121212;
+      border-color: var(--ee-primary);
+    }
+
+    .wizard-steps__step--completed & {
+      background: var(--ee-success);
+      color: #121212;
+      border-color: var(--ee-success);
+    }
+  }
+
+  &__check {
+    font-size: 18px;
+  }
+
+  &__label {
+    font-size: var(--ee-font-size-md);
+    white-space: nowrap;
+    color: var(--ee-on-surface-medium);
+
+    .wizard-steps__step--active &,
+    .wizard-steps__step--completed & {
+      color: var(--ee-on-surface);
+    }
+  }
+
+  &__connector {
+    width: 40px;
+    height: 2px;
+    background: var(--ee-divider);
+    margin: 0 var(--ee-spacing-sm);
+    flex-shrink: 0;
+    transition: background var(--ee-transition-base);
+
+    &--completed {
+      background: var(--ee-success);
+    }
+  }
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/wizard-steps.spec.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/wizard-steps.spec.ts
@@ -1,0 +1,111 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { WizardSteps, WizardStep } from './wizard-steps';
+
+describe('WizardSteps', () => {
+  let component: WizardSteps;
+  let fixture: ComponentFixture<WizardSteps>;
+  const mockSteps: WizardStep[] = [
+    { label: 'Basic Info' },
+    { label: 'Select Components' },
+    { label: 'Configure' },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WizardSteps],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WizardSteps);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('steps', mockSteps);
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render all steps', () => {
+    fixture.detectChanges();
+    const stepElements = fixture.nativeElement.querySelectorAll(
+      '.wizard-steps__step'
+    );
+    expect(stepElements.length).toBe(3);
+  });
+
+  it('should display step labels', () => {
+    fixture.detectChanges();
+    const labels = fixture.nativeElement.querySelectorAll(
+      '.wizard-steps__label'
+    );
+    expect(labels[0].textContent.trim()).toBe('Basic Info');
+    expect(labels[1].textContent.trim()).toBe('Select Components');
+    expect(labels[2].textContent.trim()).toBe('Configure');
+  });
+
+  it('should mark first step as active by default', () => {
+    fixture.detectChanges();
+    const steps = fixture.nativeElement.querySelectorAll('.wizard-steps__step');
+    expect(steps[0].classList.contains('wizard-steps__step--active')).toBe(
+      true
+    );
+  });
+
+  it('should mark the correct step as active', () => {
+    fixture.componentRef.setInput('currentStep', 1);
+    fixture.detectChanges();
+
+    const steps = fixture.nativeElement.querySelectorAll('.wizard-steps__step');
+    expect(steps[0].classList.contains('wizard-steps__step--completed')).toBe(
+      true
+    );
+    expect(steps[1].classList.contains('wizard-steps__step--active')).toBe(
+      true
+    );
+    expect(steps[2].classList.contains('wizard-steps__step--active')).toBe(
+      false
+    );
+  });
+
+  it('should show step numbers in indicators', () => {
+    fixture.detectChanges();
+    const indicators = fixture.nativeElement.querySelectorAll(
+      '.wizard-steps__indicator'
+    );
+    expect(indicators[1].textContent.trim()).toBe('2');
+    expect(indicators[2].textContent.trim()).toBe('3');
+  });
+
+  it('should show check icon for completed steps', () => {
+    fixture.componentRef.setInput('currentStep', 2);
+    fixture.detectChanges();
+
+    const checkIcons = fixture.nativeElement.querySelectorAll(
+      '.wizard-steps__check'
+    );
+    expect(checkIcons.length).toBe(2);
+  });
+
+  it('should render connectors between steps', () => {
+    fixture.detectChanges();
+    const connectors = fixture.nativeElement.querySelectorAll(
+      '.wizard-steps__connector'
+    );
+    expect(connectors.length).toBe(2);
+  });
+
+  it('should mark connectors as completed for past steps', () => {
+    fixture.componentRef.setInput('currentStep', 2);
+    fixture.detectChanges();
+
+    const connectors = fixture.nativeElement.querySelectorAll(
+      '.wizard-steps__connector'
+    );
+    expect(
+      connectors[0].classList.contains('wizard-steps__connector--completed')
+    ).toBe(true);
+    expect(
+      connectors[1].classList.contains('wizard-steps__connector--completed')
+    ).toBe(true);
+  });
+});

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/wizard-steps.stories.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/wizard-steps.stories.ts
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { WizardSteps, WizardStep } from './wizard-steps';
+
+const meta: Meta<WizardSteps> = {
+  title: 'Components/WizardSteps',
+  component: WizardSteps,
+  tags: ['autodocs'],
+  argTypes: {
+    currentStep: {
+      control: { type: 'number', min: 0 },
+      description: 'Index of the current active step',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<WizardSteps>;
+
+const defaultSteps: WizardStep[] = [
+  { label: 'Basic Info' },
+  { label: 'Select Components' },
+  { label: 'Configure' },
+];
+
+export const StepOne: Story = {
+  args: {
+    steps: defaultSteps,
+    currentStep: 0,
+  },
+};
+
+export const StepTwo: Story = {
+  args: {
+    steps: defaultSteps,
+    currentStep: 1,
+  },
+};
+
+export const StepThree: Story = {
+  args: {
+    steps: defaultSteps,
+    currentStep: 2,
+  },
+};
+
+export const AllCompleted: Story = {
+  args: {
+    steps: [
+      { label: 'Basic Info', completed: true },
+      { label: 'Select Components', completed: true },
+      { label: 'Configure', completed: true },
+    ],
+    currentStep: 3,
+  },
+};
+
+export const FiveSteps: Story = {
+  args: {
+    steps: [
+      { label: 'Start' },
+      { label: 'Details' },
+      { label: 'Components' },
+      { label: 'Review' },
+      { label: 'Complete' },
+    ],
+    currentStep: 2,
+  },
+};

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/wizard-steps.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/lib/wizard-steps/wizard-steps.ts
@@ -1,0 +1,18 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface WizardStep {
+  label: string;
+  completed?: boolean;
+}
+
+@Component({
+  selector: 'ee-wizard-steps',
+  imports: [CommonModule],
+  templateUrl: './wizard-steps.html',
+  styleUrl: './wizard-steps.scss',
+})
+export class WizardSteps {
+  steps = input.required<WizardStep[]>();
+  currentStep = input<number>(0);
+}

--- a/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/public-api.ts
+++ b/src/Endpoint.Engineering.Workspace/projects/endpoint-engineering-components/src/public-api.ts
@@ -2,4 +2,53 @@
  * Public API Surface of endpoint-engineering-components
  */
 
-export * from './lib/endpoint-engineering-components';
+// Badge
+export * from './lib/badge';
+
+// Button
+export * from './lib/button';
+
+// Config Card
+export * from './lib/config-card';
+
+// Dialog
+export * from './lib/dialog';
+
+// Empty State
+export * from './lib/empty-state';
+
+// Form Section
+export * from './lib/form-section';
+
+// Icon Button
+export * from './lib/icon-button';
+
+// Log Output
+export * from './lib/log-output';
+
+// Page Header
+export * from './lib/page-header';
+
+// Progress Bar
+export * from './lib/progress-bar';
+
+// Quick Option
+export * from './lib/quick-option';
+
+// Search Box
+export * from './lib/search-box';
+
+// Stage List
+export * from './lib/stage-list';
+
+// Stats Bar
+export * from './lib/stats-bar';
+
+// Tag
+export * from './lib/tag';
+
+// Warning Box
+export * from './lib/warning-box';
+
+// Wizard Steps
+export * from './lib/wizard-steps';


### PR DESCRIPTION
Implement 17 reusable Angular components based on the UI mockups in the designs folder, following the coding guidelines. All components include:
- Separate HTML, SCSS, and TypeScript files per guidelines
- Storybook stories with multiple variants
- Unit tests achieving >80% coverage (99.79% stmt, 86.93% branch, 100% lines)
- Barrel exports for easy importing

Components created:
- Badge: Status badges (success, processing, pending, error)
- Button: Primary, secondary, and danger button variants
- ConfigCard: Configuration display cards with meta and tags
- Dialog: Modal dialogs with header, content, and actions
- EmptyState: Empty state displays with icons and actions
- FormSection: Form container sections with titles
- IconButton: Icon-only buttons with variants
- LogOutput: Terminal-style log display with levels
- PageHeader: Application header with navigation
- ProgressBar: Animated progress indicators
- QuickOption: Quick action option cards
- SearchBox: Search input with clear functionality
- StageList: Execution stage status list
- StatsBar: Statistics display bar
- Tag: Tag chips with variants (github, local, etc.)
- WarningBox: Alert boxes (warning, error, info, success)
- WizardSteps: Multi-step wizard indicators

All components use the Angular Material dark theme color palette defined in _variables.scss and follow BEM CSS naming methodology.